### PR TITLE
Harden network egress when domain allowlist is active

### DIFF
--- a/crates/shuru-proxy/src/config.rs
+++ b/crates/shuru-proxy/src/config.rs
@@ -43,6 +43,13 @@ pub struct NetworkConfig {
     pub allow: Vec<String>,
 }
 
+impl NetworkConfig {
+    /// Returns true if a domain allowlist is configured.
+    pub fn has_allowlist(&self) -> bool {
+        !self.allow.is_empty()
+    }
+}
+
 impl ProxyConfig {
     /// Check if a domain is allowed by the network policy.
     /// Empty allowlist means all domains are allowed.
@@ -144,5 +151,16 @@ mod tests {
         assert!(domain_matches("*.example.com", "deep.api.example.com"));
         assert!(!domain_matches("*.example.com", "example.com"));
         assert!(!domain_matches("*.example.com", "notexample.com"));
+    }
+
+    #[test]
+    fn test_has_allowlist() {
+        let empty = NetworkConfig::default();
+        assert!(!empty.has_allowlist());
+
+        let with_entries = NetworkConfig {
+            allow: vec!["api.example.com".into()],
+        };
+        assert!(with_entries.has_allowlist());
     }
 }

--- a/crates/shuru-proxy/src/device.rs
+++ b/crates/shuru-proxy/src/device.rs
@@ -47,13 +47,29 @@ impl VZDevice {
     /// Drain all available frames from the socketpair (non-blocking).
     /// Call this before `Interface::poll()` so we can inspect frames
     /// (e.g. to detect TCP SYN and dynamically add listening sockets).
+    /// ICMP frames are silently dropped — the proxy only handles TCP and
+    /// DNS (UDP 53). Without this filter, smoltcp auto-replies to ICMP
+    /// echo requests for any IP (due to any_ip=true), which leaks a
+    /// response channel even though no data actually reaches the internet.
     pub fn drain_recv(&mut self) {
         while self.pending_rx.len() < MAX_PENDING_FRAMES {
             match self.recv_one_frame() {
+                Some(frame) if Self::is_icmp(&frame) => continue,
                 Some(frame) => self.pending_rx.push_back(frame),
                 None => break,
             }
         }
+    }
+
+    /// Check if a raw Ethernet frame carries an ICMP packet.
+    /// Ethernet header: dst(6) + src(6) + ethertype(2) = 14 bytes.
+    /// IPv4 header byte 9 (offset 23 from frame start) is the protocol field.
+    fn is_icmp(frame: &[u8]) -> bool {
+        const ETHERTYPE_IPV4: [u8; 2] = [0x08, 0x00];
+        const IP_PROTO_ICMP: u8 = 1;
+        frame.len() >= 24
+            && frame[12..14] == ETHERTYPE_IPV4
+            && frame[23] == IP_PROTO_ICMP
     }
 
     /// Iterate over all pending frames for inspection (e.g. SYN detection).
@@ -107,12 +123,18 @@ impl Device for VZDevice {
 
     fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
         // First drain pre-read frames, then try reading directly from the
-        // socketpair for frames that arrived during poll.
-        let buffer = self
-            .pending_rx
-            .pop_front()
-            .or_else(|| self.recv_one_frame())?;
-        Some((VZRxToken { buffer }, VZTxToken { fd: self.fd }))
+        // socketpair for frames that arrived during poll. Drop ICMP in both
+        // paths to match the filter in drain_recv().
+        loop {
+            let buffer = self
+                .pending_rx
+                .pop_front()
+                .or_else(|| self.recv_one_frame())?;
+            if Self::is_icmp(&buffer) {
+                continue;
+            }
+            return Some((VZRxToken { buffer }, VZTxToken { fd: self.fd }));
+        }
     }
 
     fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
@@ -131,5 +153,55 @@ impl Device for VZDevice {
         caps.checksum.udp = Checksum::Tx;
         caps.checksum.icmpv4 = Checksum::Tx;
         caps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal Ethernet + IPv4 frame with the given IP protocol number.
+    /// Ethernet: dst(6) + src(6) + ethertype(2) = 14 bytes
+    /// IPv4: version/IHL(1) + DSCP(1) + length(2) + id(2) + flags(2) + TTL(1) + proto(1) + ...
+    fn make_frame(ip_proto: u8) -> Vec<u8> {
+        let mut frame = vec![0u8; 34]; // 14 (eth) + 20 (ip min)
+        // EtherType = IPv4
+        frame[12] = 0x08;
+        frame[13] = 0x00;
+        // IPv4 version + IHL
+        frame[14] = 0x45;
+        // Protocol field at IPv4 offset 9 = frame offset 23
+        frame[23] = ip_proto;
+        frame
+    }
+
+    #[test]
+    fn is_icmp_detects_icmp() {
+        assert!(VZDevice::is_icmp(&make_frame(1))); // ICMP
+    }
+
+    #[test]
+    fn is_icmp_ignores_tcp() {
+        assert!(!VZDevice::is_icmp(&make_frame(6))); // TCP
+    }
+
+    #[test]
+    fn is_icmp_ignores_udp() {
+        assert!(!VZDevice::is_icmp(&make_frame(17))); // UDP
+    }
+
+    #[test]
+    fn is_icmp_ignores_arp() {
+        let mut frame = vec![0u8; 42]; // ARP is 28 bytes + 14 eth
+        // EtherType = ARP (0x0806), not IPv4
+        frame[12] = 0x08;
+        frame[13] = 0x06;
+        assert!(!VZDevice::is_icmp(&frame));
+    }
+
+    #[test]
+    fn is_icmp_ignores_short_frames() {
+        assert!(!VZDevice::is_icmp(&[]));
+        assert!(!VZDevice::is_icmp(&[0u8; 23])); // too short to read proto field
     }
 }

--- a/crates/shuru-proxy/src/dns.rs
+++ b/crates/shuru-proxy/src/dns.rs
@@ -1,4 +1,4 @@
-use std::net::UdpSocket;
+use std::net::{Ipv4Addr, UdpSocket};
 
 use simple_dns::Packet;
 use smoltcp::wire::IpEndpoint;
@@ -7,17 +7,21 @@ use tracing::debug;
 
 use crate::config::ProxyConfig;
 use crate::stack::StackCommand;
+use crate::AllowedIps;
 
 /// Handle a DNS query from the guest.
 ///
 /// Resolves the query on the host and sends the response back via the stack.
+/// When the domain allowlist is active, resolved IPs are added to the
+/// allowed set so the proxy can enforce IP-level filtering.
 pub async fn handle_dns_query(
     src: IpEndpoint,
     payload: Vec<u8>,
     cmd_tx: mpsc::UnboundedSender<StackCommand>,
     config: &ProxyConfig,
+    allowed_ips: &AllowedIps,
 ) {
-    let response = match resolve_query(&payload, &config).await {
+    let response = match resolve_query(&payload, config, allowed_ips).await {
         Ok(resp) => resp,
         Err(e) => {
             debug!("DNS resolution failed: {e}");
@@ -31,7 +35,11 @@ pub async fn handle_dns_query(
     });
 }
 
-async fn resolve_query(query_bytes: &[u8], config: &ProxyConfig) -> anyhow::Result<Vec<u8>> {
+async fn resolve_query(
+    query_bytes: &[u8],
+    config: &ProxyConfig,
+    allowed_ips: &AllowedIps,
+) -> anyhow::Result<Vec<u8>> {
     let query = Packet::parse(query_bytes)?;
 
     let question = query
@@ -56,7 +64,7 @@ async fn resolve_query(query_bytes: &[u8], config: &ProxyConfig) -> anyhow::Resu
     // reach exposed host ports without knowing the raw IP.
     if domain == "host.shuru.internal" {
         debug!("DNS host.shuru.internal -> 10.0.0.1");
-        return build_a_response(query_bytes, std::net::Ipv4Addr::new(10, 0, 0, 1));
+        return build_a_response(query_bytes, Ipv4Addr::new(10, 0, 0, 1));
     }
 
     debug!("DNS query: {domain}");
@@ -73,7 +81,35 @@ async fn resolve_query(query_bytes: &[u8], config: &ProxyConfig) -> anyhow::Resu
     })
     .await??;
 
+    // Pin resolved IPs so the proxy allows direct connections to them.
+    if config.network.has_allowlist() {
+        pin_resolved_ips(&response_bytes, allowed_ips);
+    }
+
     Ok(response_bytes)
+}
+
+/// Extract A record IPs from a DNS response and add them to the allowed set.
+fn pin_resolved_ips(response: &[u8], allowed_ips: &AllowedIps) {
+    let packet = match Packet::parse(response) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let mut ips = Vec::new();
+    for answer in &packet.answers {
+        if let simple_dns::rdata::RData::A(a) = &answer.rdata {
+            ips.push(Ipv4Addr::from(a.address));
+        }
+    }
+
+    if !ips.is_empty() {
+        let mut set = allowed_ips.write().expect("allowed_ips lock poisoned");
+        for ip in &ips {
+            debug!("DNS pin: {ip}");
+            set.insert(*ip);
+        }
+    }
 }
 
 /// Forward a raw DNS query to the system resolver and return the raw response.
@@ -103,7 +139,7 @@ fn build_empty_response(query_bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
 }
 
 /// Build a DNS A-record response pointing to the given IPv4 address.
-fn build_a_response(query_bytes: &[u8], addr: std::net::Ipv4Addr) -> anyhow::Result<Vec<u8>> {
+fn build_a_response(query_bytes: &[u8], addr: Ipv4Addr) -> anyhow::Result<Vec<u8>> {
     use simple_dns::{rdata, ResourceRecord, CLASS};
 
     let query = Packet::parse(query_bytes)?;
@@ -127,4 +163,58 @@ fn build_a_response(query_bytes: &[u8], addr: std::net::Ipv4Addr) -> anyhow::Res
 
 fn build_refused_response(query_bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
     build_response_with_rcode(query_bytes, 5)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    /// Build a minimal DNS A query for testing.
+    fn build_a_query(domain: &str) -> Vec<u8> {
+        use simple_dns::{Name, Packet, Question, QCLASS, QTYPE};
+        let mut packet = Packet::new_query(1);
+        packet.questions.push(Question::new(
+            Name::new_unchecked(domain),
+            QTYPE::TYPE(simple_dns::TYPE::A),
+            QCLASS::CLASS(simple_dns::CLASS::IN),
+            false,
+        ));
+        packet.build_bytes_vec().unwrap()
+    }
+
+    #[test]
+    fn pin_resolved_ips_extracts_a_records() {
+        let query = build_a_query("example.com");
+        let response = build_a_response(&query, Ipv4Addr::new(93, 184, 216, 34)).unwrap();
+
+        let allowed: AllowedIps = Arc::new(RwLock::new(HashSet::new()));
+        pin_resolved_ips(&response, &allowed);
+
+        let set = allowed.read().unwrap();
+        assert!(set.contains(&Ipv4Addr::new(93, 184, 216, 34)));
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn pin_resolved_ips_ignores_invalid_response() {
+        let allowed: AllowedIps = Arc::new(RwLock::new(HashSet::new()));
+        pin_resolved_ips(b"not a dns packet", &allowed);
+
+        let set = allowed.read().unwrap();
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn pin_resolved_ips_ignores_empty_response() {
+        let query = build_a_query("example.com");
+        let response = build_empty_response(&query).unwrap();
+
+        let allowed: AllowedIps = Arc::new(RwLock::new(HashSet::new()));
+        pin_resolved_ips(&response, &allowed);
+
+        let set = allowed.read().unwrap();
+        assert!(set.is_empty());
+    }
 }

--- a/crates/shuru-proxy/src/lib.rs
+++ b/crates/shuru-proxy/src/lib.rs
@@ -8,14 +8,22 @@ mod tls;
 
 pub use config::ProxyConfig;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::net::Ipv4Addr;
 use std::os::unix::io::RawFd;
+use std::sync::{Arc, RwLock};
 
 use proxy::ProxyEngine;
 use stack::NetworkStack;
 use tls::CertificateAuthority;
 use tokio::sync::mpsc;
 use tracing::info;
+
+/// Set of IPs that the proxy is allowed to connect to.
+/// Populated by DNS resolution of allowed domains. When the domain allowlist
+/// is active, TCP connections to IPs not in this set are rejected — closing
+/// the bypass where a guest connects directly to a hardcoded IP.
+pub type AllowedIps = Arc<RwLock<HashSet<Ipv4Addr>>>;
 
 /// Handle to a running proxy. Shuts down on drop.
 pub struct ProxyHandle {
@@ -94,6 +102,11 @@ pub fn start(host_fd: RawFd, config: ProxyConfig) -> anyhow::Result<ProxyHandle>
         placeholders.insert(name.clone(), generate_placeholder());
     }
 
+    // Seed allowed IPs with the gateway so expose-host always works.
+    let mut initial_ips = HashSet::new();
+    initial_ips.insert(Ipv4Addr::new(10, 0, 0, 1));
+    let allowed_ips: AllowedIps = Arc::new(RwLock::new(initial_ips));
+
     let (event_tx, event_rx) = mpsc::unbounded_channel();
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
 
@@ -106,6 +119,7 @@ pub fn start(host_fd: RawFd, config: ProxyConfig) -> anyhow::Result<ProxyHandle>
 
     let proxy_config = config;
     let proxy_placeholders = placeholders.clone();
+    let proxy_allowed_ips = allowed_ips.clone();
     let runtime_thread = std::thread::Builder::new()
         .name("shuru-proxy".into())
         .spawn(move || {
@@ -117,7 +131,7 @@ pub fn start(host_fd: RawFd, config: ProxyConfig) -> anyhow::Result<ProxyHandle>
 
             rt.block_on(async move {
                 let mut engine =
-                    ProxyEngine::new(proxy_config, event_rx, cmd_tx, ca, proxy_placeholders);
+                    ProxyEngine::new(proxy_config, event_rx, cmd_tx, ca, proxy_placeholders, proxy_allowed_ips);
                 engine.run().await;
             });
         })?;

--- a/crates/shuru-proxy/src/proxy.rs
+++ b/crates/shuru-proxy/src/proxy.rs
@@ -13,6 +13,7 @@ use crate::dns;
 use crate::stack::{ConnectionId, StackCommand, StackEvent, TcpConnection};
 use crate::stream::ChannelStream;
 use crate::tls::CertificateAuthority;
+use crate::AllowedIps;
 
 /// The async proxy engine.
 ///
@@ -30,6 +31,7 @@ pub struct ProxyEngine {
     placeholders: Arc<HashMap<String, String>>,
     ca: Arc<tokio::sync::Mutex<CertificateAuthority>>,
     upstream_ssl: SslConnector,
+    allowed_ips: AllowedIps,
 }
 
 impl ProxyEngine {
@@ -39,6 +41,7 @@ impl ProxyEngine {
         cmd_tx: mpsc::UnboundedSender<StackCommand>,
         ca: CertificateAuthority,
         placeholders: HashMap<String, String>,
+        allowed_ips: AllowedIps,
     ) -> Self {
         // BoringSSL upstream connector — Chrome's TLS stack so Cloudflare
         // doesn't reject our MITM connections based on JA3/JA4 fingerprint.
@@ -56,6 +59,7 @@ impl ProxyEngine {
             placeholders: Arc::new(placeholders),
             ca: Arc::new(tokio::sync::Mutex::new(ca)),
             upstream_ssl,
+            allowed_ips,
         }
     }
 
@@ -80,8 +84,9 @@ impl ProxyEngine {
                 StackEvent::DnsQuery { src, payload } => {
                     let cmd_tx = self.cmd_tx.clone();
                     let config = self.config.clone();
+                    let allowed_ips = self.allowed_ips.clone();
                     tokio::spawn(async move {
-                        dns::handle_dns_query(src, payload, cmd_tx, &config).await;
+                        dns::handle_dns_query(src, payload, cmd_tx, &config, &allowed_ips).await;
                     });
                 }
             }
@@ -97,6 +102,7 @@ impl ProxyEngine {
         let ca = self.ca.clone();
         let placeholders = self.placeholders.clone();
         let upstream_ssl = self.upstream_ssl.clone();
+        let allowed_ips = self.allowed_ips.clone();
 
         tokio::spawn(async move {
             if let Err(e) = handle_connection(
@@ -108,6 +114,7 @@ impl ProxyEngine {
                 ca,
                 &placeholders,
                 upstream_ssl,
+                &allowed_ips,
             )
             .await
             {
@@ -127,6 +134,7 @@ async fn handle_connection(
     ca: Arc<tokio::sync::Mutex<CertificateAuthority>>,
     placeholders: &HashMap<String, String>,
     upstream_ssl: SslConnector,
+    allowed_ips: &AllowedIps,
 ) -> anyhow::Result<()> {
     // Check if this is a connection to an exposed host port (host.shuru.internal).
     if let std::net::IpAddr::V4(ipv4) = dst.ip() {
@@ -139,6 +147,22 @@ async fn handle_connection(
             let upstream = TcpStream::connect(local_dst).await?;
             let (mut upstream_rd, mut upstream_wr) = upstream.into_split();
             return blind_relay(id, &mut upstream_rd, &mut upstream_wr, data_rx, cmd_tx).await;
+        }
+    }
+
+    // When a domain allowlist is active, only allow connections to IPs that
+    // were resolved via the DNS handler. This prevents bypass via hardcoded IPs.
+    if config.network.has_allowlist() {
+        if let std::net::IpAddr::V4(ipv4) = dst.ip() {
+            let is_allowed = allowed_ips
+                .read()
+                .expect("allowed_ips lock poisoned")
+                .contains(&ipv4);
+            if !is_allowed {
+                debug!("IP not in DNS-pinned set, rejecting: {dst}");
+                let _ = cmd_tx.send(StackCommand::Close { id });
+                return Err(anyhow::anyhow!("connection to {dst} blocked: IP not resolved via allowed DNS"));
+            }
         }
     }
 
@@ -167,6 +191,25 @@ async fn handle_connection(
 
         let sni = extract_sni(&tls_buf);
         debug!("TLS to {dst}, SNI: {sni:?}");
+
+        // When a domain allowlist is active, verify the SNI matches an
+        // allowed domain. This prevents connecting to non-allowed services
+        // that happen to share an IP with an allowed domain (e.g. CDN/Cloudflare).
+        if config.network.has_allowlist() {
+            match &sni {
+                Some(domain) if !config.is_domain_allowed(domain) => {
+                    debug!("SNI not in allowlist, rejecting: {domain}");
+                    let _ = cmd_tx.send(StackCommand::Close { id });
+                    return Err(anyhow::anyhow!("TLS to {dst} blocked: SNI '{domain}' not in allowlist"));
+                }
+                None => {
+                    debug!("no SNI in ClientHello, rejecting connection to {dst}");
+                    let _ = cmd_tx.send(StackCommand::Close { id });
+                    return Err(anyhow::anyhow!("TLS to {dst} blocked: no SNI"));
+                }
+                _ => {}
+            }
+        }
 
         if let Some(domain) = sni {
             let substitutions = config.secrets_for_domain(&domain, placeholders);


### PR DESCRIPTION
## Summary

When `network.allow` (domain allowlist) is configured, the proxy only blocked DNS resolution for non-allowed domains. A guest that knew a target IP could bypass the allowlist entirely — e.g. via `curl --resolve` with a hardcoded IP, or raw TCP sockets.

This PR closes three egress gaps:

- **DNS-pinning**: after resolving an allowed domain, record the resulting A-record IPs in a shared `HashSet`. Reject TCP connections to IPs not in that set.
- **SNI filtering**: on TLS connections to pinned IPs, verify the SNI hostname matches an allowed domain before proxying. Prevents accessing non-allowed Cloudflare-fronted services that share an IP.
- **ICMP drop**: filter ICMP frames at the device level before smoltcp processes them. smoltcp auto-replies to echo requests for any IP (due to `any_ip=true`), which leaks a response channel even though no data reaches the internet.

All three checks are only active when `network.allow` is non-empty. Without an allowlist, behavior is unchanged.

## Changes

| File | Change |
|---|---|
| `config.rs` | `has_allowlist()` helper |
| `lib.rs` | `AllowedIps` shared type (`Arc<RwLock<HashSet<Ipv4Addr>>>`), seeded with gateway IP |
| `dns.rs` | `pin_resolved_ips()` — extract A records after resolution, add to allowed set |
| `proxy.rs` | IP check + SNI check in `handle_connection` |
| `device.rs` | Drop ICMP frames in `drain_recv()` and `receive()` |

## Test plan

- [x] `cargo test -p shuru-proxy` — 15 tests pass (8 new)
- [x] `cargo check -p shuru-cli` — compiles clean
- [x] Manual: `curl --resolve` with hardcoded IP → blocked (HTTP 000)
- [x] Manual: `curl` to allowed domain via DNS → works (HTTP 404)
- [x] Manual: TLS with non-allowed SNI on pinned IP → blocked (HTTP 000)
- [x] Manual: ICMP echo request from root → no reply (timeout)
- [x] No allowlist configured → all traffic passes as before