### PR TITLE
deps: bump tar from 0.4.44 to 0.4.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/crates/shuru-cli/Cargo.toml
+++ b/crates/shuru-cli/Cargo.toml
@@ -22,7 +22,7 @@ libc = "0.2"
 flate2 = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tar = "0.4"
+tar = "0.4.45"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ureq = { version = "3", features = ["json"] }

--- a/crates/shuru-guest/Cargo.toml
+++ b/crates/shuru-guest/Cargo.toml
@@ -13,6 +13,6 @@ libc = "0.2"
 serde_json = "1"
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 flate2 = "1"
-tar = "0.4"
+tar = "0.4.45"
 ignore = "0.4"
 notify = "7"


### PR DESCRIPTION
## Summary
- Bumps `tar` from 0.4.44 to 0.4.45 in `shuru-cli` and `shuru-guest`

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)