### PR TITLE
store: validate chunk index fields on load

### DIFF
--- a/crates/shuru-store/src/cas.rs
+++ b/crates/shuru-store/src/cas.rs
@@ -64,6 +64,7 @@ impl ChunkStore for LocalChunkStore {
 
 /// Index mapping chunk positions to hashes. One index per disk image / checkpoint.
 /// ZERO entries mean "ask parent" — enables delta-only checkpoints.
+#[derive(Debug)]
 pub struct ChunkIndex {
     hashes: Vec<String>,
     disk_size: u64,
@@ -139,6 +140,13 @@ impl ChunkIndex {
         f.read_exact(&mut buf8)?;
         let num_chunks = u64::from_le_bytes(buf8) as usize;
 
+        let expected_chunks = ((disk_size + CHUNK_SIZE as u64 - 1) / CHUNK_SIZE as u64) as usize;
+        anyhow::ensure!(
+            num_chunks == expected_chunks,
+            "index {}: chunk count {} does not match disk_size {} (expected {})",
+            path, num_chunks, disk_size, expected_chunks,
+        );
+
         // Parent path
         let mut buf4 = [0u8; 4];
         f.read_exact(&mut buf4)?;
@@ -171,6 +179,16 @@ impl ChunkIndex {
         }
 
         Ok(ChunkIndex { hashes, disk_size, parent_path, fallback_path })
+    }
+
+    /// Validate that disk_size does not exceed the given backing store size.
+    pub fn check_size_against_backend(&self, backend_size: u64, label: &str) -> Result<()> {
+        anyhow::ensure!(
+            self.disk_size <= backend_size,
+            "index disk_size ({}) exceeds {} size ({})",
+            self.disk_size, label, backend_size,
+        );
+        Ok(())
     }
 }
 
@@ -475,5 +493,31 @@ mod tests {
         let mut buf = vec![0u8; data.len()];
         backend.read(offset, &mut buf).unwrap();
         assert_eq!(&buf, data);
+    }
+
+    #[test]
+    fn test_load_rejects_mismatched_chunk_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        let idx_path = tmp.path().join("bad.idx");
+
+        // Write an index with disk_size=64KB (1 chunk) but num_chunks=100
+        let mut f = fs::File::create(&idx_path).unwrap();
+        f.write_all(&(CHUNK_SIZE as u64).to_le_bytes()).unwrap(); // disk_size
+        f.write_all(&100u64.to_le_bytes()).unwrap(); // num_chunks (should be 1)
+        f.write_all(&0u32.to_le_bytes()).unwrap(); // parent_path len
+        f.write_all(&0u32.to_le_bytes()).unwrap(); // fallback_path len
+        drop(f);
+
+        let err = ChunkIndex::load(idx_path.to_str().unwrap()).unwrap_err();
+        assert!(err.to_string().contains("chunk count"), "{}", err);
+    }
+
+    #[test]
+    fn test_check_size_against_backend() {
+        let index = ChunkIndex::new(1024 * 1024); // 1MB
+        assert!(index.check_size_against_backend(1024 * 1024, "test").is_ok());
+        assert!(index.check_size_against_backend(2 * 1024 * 1024, "test").is_ok());
+        let err = index.check_size_against_backend(512 * 1024, "test").unwrap_err();
+        assert!(err.to_string().contains("exceeds"), "{}", err);
     }
 }

--- a/crates/shuru-store/src/cas.rs
+++ b/crates/shuru-store/src/cas.rs
@@ -64,7 +64,6 @@ impl ChunkStore for LocalChunkStore {
 
 /// Index mapping chunk positions to hashes. One index per disk image / checkpoint.
 /// ZERO entries mean "ask parent" — enables delta-only checkpoints.
-#[derive(Debug)]
 pub struct ChunkIndex {
     hashes: Vec<String>,
     disk_size: u64,
@@ -508,8 +507,10 @@ mod tests {
         f.write_all(&0u32.to_le_bytes()).unwrap(); // fallback_path len
         drop(f);
 
-        let err = ChunkIndex::load(idx_path.to_str().unwrap()).unwrap_err();
-        assert!(err.to_string().contains("chunk count"), "{}", err);
+        match ChunkIndex::load(idx_path.to_str().unwrap()) {
+            Err(e) => assert!(e.to_string().contains("chunk count")),
+            Ok(_) => panic!("expected load to fail for mismatched chunk count"),
+        }
     }
 
     #[test]
@@ -517,7 +518,9 @@ mod tests {
         let index = ChunkIndex::new(1024 * 1024); // 1MB
         assert!(index.check_size_against_backend(1024 * 1024, "test").is_ok());
         assert!(index.check_size_against_backend(2 * 1024 * 1024, "test").is_ok());
-        let err = index.check_size_against_backend(512 * 1024, "test").unwrap_err();
-        assert!(err.to_string().contains("exceeds"), "{}", err);
+        match index.check_size_against_backend(512 * 1024, "test") {
+            Err(e) => assert!(e.to_string().contains("exceeds")),
+            Ok(_) => panic!("expected size check to fail"),
+        }
     }
 }

--- a/crates/shuru-store/src/lib.rs
+++ b/crates/shuru-store/src/lib.rs
@@ -135,10 +135,13 @@ pub fn start_cas_nbd_server(
     let (index, fallback, source_idx) = if Path::new(index_path).exists() {
         info!("loading CAS index from {}", index_path);
         let idx = ChunkIndex::load(index_path)?;
-        // If the index has a fallback_path, open it for chain resolution
+        // If the index has a fallback_path, open it and validate disk_size
         let fb = idx.fallback_path.as_ref().and_then(|p| {
             FlatFileBackend::open(p).ok()
         });
+        if let Some(ref fb) = fb {
+            idx.check_size_against_backend(fb.size(), "fallback file")?;
+        }
         (idx, fb, Some(index_path.to_string()))
     } else {
         // No index yet — create empty index with fallback to flat file for lazy ingestion


### PR DESCRIPTION
## Summary
- Validate that `num_chunks` in `.idx` files is consistent with the declared `disk_size` during `ChunkIndex::load()`
- Add `check_size_against_backend()` to reject indexes whose `disk_size` exceeds the actual backing store
- Prevents out-of-bounds reads when an index file contains invalid length fields

## Test plan
- [x] `cargo test -p shuru-store` — all 8 tests pass
- [x] New test: `test_load_rejects_mismatched_chunk_count` — verifies load fails on inconsistent index
- [x] New test: `test_check_size_against_backend` — verifies size validation against backing store