### PR TITLE
linux: complete open flag check for read-only virtiofs mounts

### DIFF
--- a/crates/shuru-linux/src/kvm/virtio_fs.rs
+++ b/crates/shuru-linux/src/kvm/virtio_fs.rs
@@ -1273,7 +1273,7 @@ impl VirtioFsBackend {
             Some(p) => p,
             None => return (-libc::ENOENT, 0),
         };
-        let wants_write = req.flags as i32 & (libc::O_WRONLY | libc::O_RDWR | libc::O_APPEND) != 0;
+        let wants_write = req.flags as i32 & (libc::O_WRONLY | libc::O_RDWR | libc::O_APPEND | libc::O_TRUNC) != 0;
         if wants_write && inodes.read_only {
             return (-libc::EROFS, 0);
         }


### PR DESCRIPTION
## Summary
- Add missing `O_TRUNC` to the set of flags checked when enforcing read-only mounts in the virtiofs FUSE OPEN handler

## Test plan
- [x] Verify read-only mount rejects opens with `O_TRUNC`
- [x] Verify normal read-only opens still succeed

