### PR TITLE
fix(store): flip disk_size vs fallback size validation direction

### DIFF
--- a/crates/shuru-store/src/cas.rs
+++ b/crates/shuru-store/src/cas.rs
@@ -180,12 +180,13 @@ impl ChunkIndex {
         Ok(ChunkIndex { hashes, disk_size, parent_path, fallback_path })
     }
 
-    /// Validate that disk_size does not exceed the given backing store size.
+    /// Validate that the given backing store size does not exceed disk_size.
+    /// The virtual disk may be larger than the flat file (sparse expansion is valid).
     pub fn check_size_against_backend(&self, backend_size: u64, label: &str) -> Result<()> {
         anyhow::ensure!(
-            self.disk_size <= backend_size,
-            "index disk_size ({}) exceeds {} size ({})",
-            self.disk_size, label, backend_size,
+            backend_size <= self.disk_size,
+            "{} size ({}) exceeds index disk_size ({})",
+            label, backend_size, self.disk_size,
         );
         Ok(())
     }
@@ -515,12 +516,16 @@ mod tests {
 
     #[test]
     fn test_check_size_against_backend() {
-        let index = ChunkIndex::new(1024 * 1024); // 1MB
+        let index = ChunkIndex::new(4 * 1024 * 1024); // 4MB virtual disk
+
+        // flat file == virtual disk: ok
+        assert!(index.check_size_against_backend(4 * 1024 * 1024, "test").is_ok());
+        // flat file < virtual disk: ok (sparse expansion — the normal case)
         assert!(index.check_size_against_backend(1024 * 1024, "test").is_ok());
-        assert!(index.check_size_against_backend(2 * 1024 * 1024, "test").is_ok());
-        match index.check_size_against_backend(512 * 1024, "test") {
+        // flat file > virtual disk: corrupt — must fail
+        match index.check_size_against_backend(8 * 1024 * 1024, "test") {
             Err(e) => assert!(e.to_string().contains("exceeds")),
-            Ok(_) => panic!("expected size check to fail"),
+            Ok(_) => panic!("expected size check to fail when flat file exceeds virtual disk"),
         }
     }
 }

--- a/crates/shuru-store/src/lib.rs
+++ b/crates/shuru-store/src/lib.rs
@@ -140,7 +140,11 @@ pub fn start_cas_nbd_server(
             FlatFileBackend::open(p).ok()
         });
         if let Some(ref fb) = fb {
-            idx.check_size_against_backend(fb.size(), "fallback file")?;
+            anyhow::ensure!(
+                fb.size() <= idx.disk_size(),
+                "fallback file size ({}) exceeds index disk_size ({}); index may be corrupt",
+                fb.size(), idx.disk_size(),
+            );
         }
         (idx, fb, Some(index_path.to_string()))
     } else {


### PR DESCRIPTION
## Bug

Creating a checkpoint with any `--disk-size` larger than the base rootfs (1GB) causes all subsequent runs from that checkpoint to fail immediately.

Since the default `--disk-size` is **4096MB** and the base rootfs is **1GB**, every checkpoint created without explicit `--disk-size 1024` is broken by default.

## Environment

- shuru 0.6.2
- macOS, Apple Silicon

## Steps to Reproduce

```sh
# Create checkpoint (succeeds)
shuru checkpoint create myenv --allow-net -- echo done

# Run from checkpoint (fails)
shuru run --from myenv -- echo hello
```

## Error

```
Error: index disk_size (4294967296) exceeds fallback file size (1073741824)
```

## Root Cause

Introduced in commit [`2176600`](https://github.com/superhq-ai/shuru/commit/2176600072478b177731f8fdb6582b28a537f69a) (`store: validate chunk index fields on load`).

`shuru-store/src/lib.rs:143` added this check:

```rust
idx.check_size_against_backend(fb.size(), "fallback file")?;
```

This enforces `index.disk_size <= fallback_file.size()`.

But these are intentionally different things:
- `index.disk_size` = **virtual disk size** (4GB default, set by `set_disk_size()`)
- `fallback_file.size()` = **base rootfs file** (1GB, fixed)

The virtual disk is sparse. The read path at `cas.rs:380` already handles out-of-bounds safely:

```rust
if offset < fb.size() {
    // read from flat file — offsets beyond this return zeros
}
```

The validation is **backwards** — it was written assuming `disk_size == fb.size()`, which breaks when `set_disk_size()` expands the virtual disk beyond the flat file.

## Fix

In `crates/shuru-store/src/lib.rs`, flip or remove the check:

```rust
// WRONG (current)
idx.check_size_against_backend(fb.size(), "fallback file")?;
// enforces: disk_size <= fb.size()  ← backwards

// CORRECT: flat file must not exceed virtual disk
anyhow::ensure!(
    fb.size() <= idx.disk_size,
    "fallback file size ({}) exceeds index disk_size ({})",
    fb.size(), idx.disk_size,
);
```

## Workaround

Pass `--disk-size 1024` to match base rootfs exactly:

```sh
shuru checkpoint create myenv --allow-net --disk-size 1024 -- <command>
```