### PR TITLE
Refreshable secrets, and head-scoped substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## Unreleased
+
+### Secrets can be refreshed while the VM runs
+
+A secret can now be backed by a command that mints it, instead of a host
+environment variable that is frozen when the VM boots:
+
+```json
+"secrets": {
+  "GITHUB_TOKEN": {
+    "command": ["./scripts/mint-installation-token.sh"],
+    "hosts": ["api.github.com", "github.com"]
+  }
+}
+```
+
+The command prints `{"version":1,"value":"...","expires_at":"..."}` and the
+proxy re-runs it as the value nears expiry, so credentials with short
+lifetimes (GitHub App installation tokens last an hour) no longer strand a
+long running task. The placeholder inside the guest never changes, so the
+rotation is invisible to the VM and the real value still never enters it.
+Set `ttl` for a command that cannot report an expiry of its own.
+
+Values are held in memory only, resolution is single flight so a burst of
+requests mints once, and a command that fails while a live value is cached
+keeps serving that value. A command that fails with nothing usable cached
+refuses the connection instead of sending a placeholder upstream.
+
+See docs/rfcs/0002-refreshable-secrets.md.
+
+Secrets are resolved per connection, so a connection held open across the
+expiry keeps its original value until it reconnects.
+
+shuru-proxy 0.3.0 and shuru-sdk 0.4.0 are breaking for direct consumers:
+`SecretConfig.from` is now `Option<String>`. Use `SecretConfig::from_env`
+or `SecretConfig::from_command`.
+
 ## 0.6.5
 
 ### Direct disk mode is now the default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,32 @@ refuses the connection instead of sending a placeholder upstream.
 
 See docs/rfcs/0002-refreshable-secrets.md.
 
-Secrets are resolved per connection, so a connection held open across the
-expiry keeps its original value until it reconnects.
+### Secrets are substituted in the request head
+
+Substitution used to be a blind byte replace over the whole stream, which had
+two consequences. A placeholder straddling two reads was forwarded
+unsubstituted, so the secret never got injected: reproduced on a large upload
+where 3 of 2000 placeholders leaked. And a secret in a request body broke the
+declared body length, hanging the request.
+
+Substitution now applies to the request line and any header value, whatever
+the header is named, so a custom `X-My-Vendor-Token` needs no configuration
+and a credential in a query parameter is covered. Bodies stream through
+untouched, so no declared length is ever invalidated. HTTP framing is read
+but never rewritten, only to find where the next request begins on a reused
+connection, and anything ambiguous falls back to a plain byte tunnel.
+
+This is also less work than before, since only heads are scanned rather than
+every byte of every body.
+
+Behaviour change: a placeholder in a request body is no longer substituted.
+That never worked for any real credential length, since placeholders are a
+fixed 30 bytes and a differing length broke framing, but the failure moves
+from a hung request to a clean 401.
+
+A live connection also re-resolves its secrets every 5 seconds, so a rotation
+reaches a connection that is already open instead of waiting for it to
+reconnect.
 
 shuru-proxy 0.3.0 and shuru-sdk 0.4.0 are breaking for direct consumers:
 `SecretConfig.from` is now `Option<String>`. Use `SecretConfig::from_env`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "shuru-proxy"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "boring",
@@ -1556,8 +1556,11 @@ dependencies = [
  "lru",
  "rcgen",
  "rustls",
+ "serde",
+ "serde_json",
  "simple-dns",
  "smoltcp",
+ "time",
  "tokio",
  "tokio-boring",
  "tokio-rustls",
@@ -1567,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "shuru-sdk"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1605,6 +1608,16 @@ dependencies = [
  "shuru-proto",
  "socket2 0.5.10",
  "tracing",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
 ]
 
 [[package]]
@@ -1826,6 +1839,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,6 +1552,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "boring",
+ "httparse",
  "libc",
  "lru",
  "rcgen",

--- a/crates/shuru-cli/src/config.rs
+++ b/crates/shuru-cli/src/config.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{bail, Result};
 use serde::Deserialize;
@@ -17,16 +19,92 @@ pub(crate) struct ShuruConfig {
     pub network: Option<NetworkEntry>,
     /// Host ports to expose to the guest (e.g. "3000:8080" or "5432").
     pub expose_host: Option<Vec<String>>,
+    /// Directory holding this config, used as the working directory for
+    /// secret provider commands. Set on load, never deserialized.
+    #[serde(skip)]
+    pub config_dir: Option<PathBuf>,
 }
 
-/// A secret to inject via the proxy.
+/// A secret to inject via the proxy. The value comes from either a host
+/// environment variable or a command that mints it, never both.
+///
 /// Example: `{ "from": "OPENAI_API_KEY", "hosts": ["api.openai.com"] }`
+/// Example: `{ "command": ["./mint.sh"], "hosts": ["api.github.com"] }`
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct SecretEntry {
     /// Host environment variable containing the real value.
-    pub from: String,
+    pub from: Option<String>,
+    /// Command that mints the value, as argv. Re-run as the value expires.
+    pub command: Option<Vec<String>>,
+    /// Lifetime to assume when the command reports no expiry of its own.
+    /// Accepts "45m", "3600s", "2h", or a bare number of seconds.
+    pub ttl: Option<String>,
     /// Domains where this secret may be sent.
     pub hosts: Vec<String>,
+}
+
+impl SecretEntry {
+    fn to_secret_config(&self, name: &str) -> Result<shuru_proxy::config::SecretConfig> {
+        let ttl = match self.ttl {
+            Some(ref ttl) => Some(
+                parse_duration(ttl)
+                    .map_err(|e| anyhow::anyhow!("secret '{name}': invalid ttl '{ttl}': {e}"))?,
+            ),
+            None => None,
+        };
+
+        match (&self.from, &self.command) {
+            (Some(_), Some(_)) => {
+                bail!("secret '{name}': set either 'from' or 'command', not both")
+            }
+            (None, None) => bail!("secret '{name}': needs either 'from' or 'command'"),
+            (Some(from), None) => {
+                if ttl.is_some() {
+                    bail!("secret '{name}': 'ttl' only applies to 'command' secrets");
+                }
+                Ok(shuru_proxy::config::SecretConfig::from_env(
+                    from.clone(),
+                    self.hosts.clone(),
+                ))
+            }
+            (None, Some(command)) => {
+                if command.is_empty() {
+                    bail!("secret '{name}': 'command' is empty");
+                }
+                Ok(shuru_proxy::config::SecretConfig {
+                    ttl,
+                    ..shuru_proxy::config::SecretConfig::from_command(
+                        command.clone(),
+                        self.hosts.clone(),
+                    )
+                })
+            }
+        }
+    }
+}
+
+/// Parse "45m", "3600s", "2h", or a bare number of seconds.
+fn parse_duration(s: &str) -> Result<Duration> {
+    let s = s.trim();
+    let (digits, multiplier) = match s.strip_suffix(['s', 'm', 'h']) {
+        Some(digits) => (
+            digits,
+            match s.as_bytes()[s.len() - 1] {
+                b's' => 1,
+                b'm' => 60,
+                _ => 3600,
+            },
+        ),
+        None => (s, 1),
+    };
+    let value: u64 = digits
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("expected a number optionally suffixed with s, m, or h"))?;
+    if value == 0 {
+        bail!("must be greater than zero");
+    }
+    Ok(Duration::from_secs(value * multiplier))
 }
 
 /// Network access policy.
@@ -37,20 +115,29 @@ pub(crate) struct NetworkEntry {
 }
 
 impl ShuruConfig {
+    /// Reject a malformed config up front, so `shuru run` fails the same way
+    /// whether or not networking is enabled.
+    pub fn validate(&self) -> Result<()> {
+        if let Some(ref secrets) = self.secrets {
+            for (name, entry) in secrets {
+                entry.to_secret_config(name)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Convert config sections into a ProxyConfig for shuru-proxy.
-    pub fn to_proxy_config(&self) -> shuru_proxy::config::ProxyConfig {
-        let mut proxy = shuru_proxy::config::ProxyConfig::default();
+    pub fn to_proxy_config(&self) -> Result<shuru_proxy::config::ProxyConfig> {
+        let mut proxy = shuru_proxy::config::ProxyConfig {
+            config_dir: self.config_dir.clone(),
+            ..Default::default()
+        };
 
         if let Some(ref secrets) = self.secrets {
             for (name, entry) in secrets {
-                proxy.secrets.insert(
-                    name.clone(),
-                    shuru_proxy::config::SecretConfig {
-                        from: entry.from.clone(),
-                        hosts: entry.hosts.clone(),
-                        value: None,
-                    },
-                );
+                proxy
+                    .secrets
+                    .insert(name.clone(), entry.to_secret_config(name)?);
             }
         }
 
@@ -68,7 +155,7 @@ impl ShuruConfig {
             }
         }
 
-        proxy
+        Ok(proxy)
     }
 }
 
@@ -109,8 +196,16 @@ pub(crate) fn load_config(config_flag: Option<&str>) -> Result<ShuruConfig> {
 
     match std::fs::read_to_string(&path) {
         Ok(contents) => {
-            let cfg: ShuruConfig = serde_json::from_str(&contents)
+            let mut cfg: ShuruConfig = serde_json::from_str(&contents)
                 .map_err(|e| anyhow::anyhow!("Failed to parse {}: {}", path.display(), e))?;
+            // Secret providers run relative to the config, not to wherever
+            // shuru happened to be invoked from.
+            cfg.config_dir = path
+                .canonicalize()
+                .ok()
+                .and_then(|p| p.parent().map(PathBuf::from));
+            cfg.validate()
+                .map_err(|e| anyhow::anyhow!("{}: {}", path.display(), e))?;
             Ok(cfg)
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -120,5 +215,92 @@ pub(crate) fn load_config(config_flag: Option<&str>) -> Result<ShuruConfig> {
             Ok(ShuruConfig::default())
         }
         Err(e) => bail!("Failed to read {}: {}", path.display(), e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_from(json: &str) -> Result<ShuruConfig> {
+        let cfg: ShuruConfig = serde_json::from_str(json)?;
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    /// ShuruConfig has no Debug impl, so unwrap_err is unavailable.
+    fn rejection(json: &str) -> String {
+        config_from(json)
+            .err()
+            .expect("config should have been rejected")
+            .to_string()
+    }
+
+    #[test]
+    fn parses_duration_suffixes() {
+        assert_eq!(parse_duration("45m").unwrap(), Duration::from_secs(2700));
+        assert_eq!(parse_duration("3600s").unwrap(), Duration::from_secs(3600));
+        assert_eq!(parse_duration("2h").unwrap(), Duration::from_secs(7200));
+        assert_eq!(parse_duration(" 90 ").unwrap(), Duration::from_secs(90));
+
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("0s").is_err());
+        assert!(parse_duration("soon").is_err());
+        assert!(parse_duration("10d").is_err());
+        assert!(parse_duration("-5m").is_err());
+    }
+
+    #[test]
+    fn accepts_either_source() {
+        let env = config_from(
+            r#"{"secrets":{"API_KEY":{"from":"OPENAI_API_KEY","hosts":["api.openai.com"]}}}"#,
+        )
+        .unwrap();
+        let proxy = env.to_proxy_config().unwrap();
+        assert_eq!(
+            proxy.secrets["API_KEY"].from.as_deref(),
+            Some("OPENAI_API_KEY")
+        );
+
+        let command = config_from(
+            r#"{"secrets":{"GH":{"command":["./mint.sh"],"ttl":"45m","hosts":["api.github.com"]}}}"#,
+        )
+        .unwrap();
+        let proxy = command.to_proxy_config().unwrap();
+        assert_eq!(
+            proxy.secrets["GH"].command.as_deref(),
+            Some(["./mint.sh".to_string()].as_slice())
+        );
+        assert_eq!(proxy.secrets["GH"].ttl, Some(Duration::from_secs(2700)));
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_incomplete_secrets() {
+        let both = rejection(
+            r#"{"secrets":{"GH":{"from":"TOKEN","command":["./mint.sh"],"hosts":["api.github.com"]}}}"#,
+        );
+        assert!(both.contains("not both"), "{both}");
+
+        let neither = rejection(r#"{"secrets":{"GH":{"hosts":["api.github.com"]}}}"#);
+        assert!(neither.contains("either 'from' or 'command'"), "{neither}");
+
+        let empty = rejection(r#"{"secrets":{"GH":{"command":[],"hosts":["api.github.com"]}}}"#);
+        assert!(empty.contains("empty"), "{empty}");
+    }
+
+    #[test]
+    fn rejects_ttl_on_an_env_secret() {
+        let err = rejection(
+            r#"{"secrets":{"GH":{"from":"TOKEN","ttl":"45m","hosts":["api.github.com"]}}}"#,
+        );
+        assert!(err.contains("only applies to 'command'"), "{err}");
+    }
+
+    #[test]
+    fn reports_the_offending_secret_by_name() {
+        let err = rejection(
+            r#"{"secrets":{"GITHUB_TOKEN":{"command":["./mint.sh"],"ttl":"soon","hosts":["api.github.com"]}}}"#,
+        );
+        assert!(err.contains("GITHUB_TOKEN"), "{err}");
     }
 }

--- a/crates/shuru-cli/src/vm.rs
+++ b/crates/shuru-cli/src/vm.rs
@@ -87,7 +87,7 @@ pub(crate) fn prepare_vm(
     let verbose = vm.verbose;
 
     let proxy_config = if allow_net {
-        let mut proxy = cfg.to_proxy_config();
+        let mut proxy = cfg.to_proxy_config()?;
 
         if let Some(resolver) = vm.dns_resolver {
             proxy.dns_resolver = resolver;
@@ -99,7 +99,7 @@ pub(crate) fn prepare_vm(
                 .with_context(|| format!("invalid --secret: '{}' (expected NAME=ENV@host1,host2)", s))?;
             proxy.secrets.insert(
                 name,
-                shuru_proxy::config::SecretConfig { from, hosts, value: None },
+                shuru_proxy::config::SecretConfig::from_env(from, hosts),
             );
         }
 

--- a/crates/shuru-proxy/Cargo.toml
+++ b/crates/shuru-proxy/Cargo.toml
@@ -23,6 +23,7 @@ boring = "4"
 tokio-boring = "4"
 simple-dns = "0.9"
 lru = "0.14"
+httparse = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 time = { version = "0.3", features = ["parsing", "formatting"] }

--- a/crates/shuru-proxy/Cargo.toml
+++ b/crates/shuru-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuru-proxy"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "Transparent network proxy for shuru microVMs"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ smoltcp = { version = "0.12", default-features = false, features = [
     "socket-tcp",
     "socket-udp",
 ] }
-tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "sync", "macros", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "sync", "macros", "time", "process"] }
 tokio-rustls = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "logging", "tls12"] }
 rcgen = "0.13"
@@ -23,6 +23,9 @@ boring = "4"
 tokio-boring = "4"
 simple-dns = "0.9"
 lru = "0.14"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+time = { version = "0.3", features = ["parsing", "formatting"] }
 anyhow = "1"
 tracing = "0.1"
 libc = "0.2"

--- a/crates/shuru-proxy/src/config.rs
+++ b/crates/shuru-proxy/src/config.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::time::Duration;
 
 /// A host port exposed to the guest via host.shuru.internal.
 #[derive(Debug, Clone)]
@@ -23,6 +25,10 @@ pub struct ProxyConfig {
     pub network: NetworkConfig,
     /// Host ports exposed to the guest via host.shuru.internal.
     pub expose_host: Vec<ExposeHostMapping>,
+    /// Working directory for secret provider commands. Normally the directory
+    /// holding the resolved shuru.json, so relative paths in a config behave
+    /// the same wherever shuru is invoked from. None inherits the process cwd.
+    pub config_dir: Option<PathBuf>,
 }
 
 impl Default for ProxyConfig {
@@ -32,20 +38,56 @@ impl Default for ProxyConfig {
             secrets: HashMap::new(),
             network: NetworkConfig::default(),
             expose_host: Vec::new(),
+            config_dir: None,
         }
     }
 }
 
 /// A secret that the proxy injects into HTTP requests.
-#[derive(Debug, Clone)]
+///
+/// The value comes from exactly one source: a host environment variable
+/// (`from`), a command that mints it (`command`), or a literal (`value`).
+#[derive(Debug, Clone, Default)]
 pub struct SecretConfig {
     /// Host environment variable to read the real value from.
-    pub from: String,
+    pub from: Option<String>,
+    /// Command to run to mint the value, as argv. Never passed to a shell.
+    /// Re-run once the minted value approaches its expiry.
+    pub command: Option<Vec<String>>,
+    /// Lifetime to assume when a command reports no expiry of its own.
+    pub ttl: Option<Duration>,
     /// Domain patterns where this secret may be sent (e.g., "api.openai.com").
     /// The proxy only substitutes the placeholder on requests to these hosts.
     pub hosts: Vec<String>,
     /// If set, use this value directly instead of reading from the host env var.
     pub value: Option<String>,
+}
+
+impl SecretConfig {
+    /// Secret backed by a host environment variable.
+    pub fn from_env(var: impl Into<String>, hosts: Vec<String>) -> Self {
+        Self {
+            from: Some(var.into()),
+            hosts,
+            ..Default::default()
+        }
+    }
+
+    /// Secret minted by running a command.
+    pub fn from_command(command: Vec<String>, hosts: Vec<String>) -> Self {
+        Self {
+            command: Some(command),
+            hosts,
+            ..Default::default()
+        }
+    }
+
+    /// True if this secret is bound to `domain`.
+    pub fn matches_domain(&self, domain: &str) -> bool {
+        self.hosts
+            .iter()
+            .any(|pattern| domain_matches(pattern, domain))
+    }
 }
 
 /// Network access policy.
@@ -88,40 +130,13 @@ impl ProxyConfig {
             .find(|m| m.guest_port == guest_port)
             .map(|m| m.host_port)
     }
-
-    /// Get all secret placeholder→real value mappings for a given domain.
-    pub fn secrets_for_domain(
-        &self,
-        domain: &str,
-        placeholders: &HashMap<String, String>,
-    ) -> Vec<(String, String)> {
-        let mut substitutions = Vec::new();
-        for (name, secret) in &self.secrets {
-            if secret
-                .hosts
-                .iter()
-                .any(|pattern| domain_matches(pattern, domain))
-            {
-                if let Some(placeholder) = placeholders.get(name) {
-                    let real_value = secret
-                        .value
-                        .clone()
-                        .or_else(|| std::env::var(&secret.from).ok());
-                    if let Some(real_value) = real_value {
-                        substitutions.push((placeholder.clone(), real_value));
-                    }
-                }
-            }
-        }
-        substitutions
-    }
 }
 
 /// Simple wildcard domain matching.
 /// "*" matches any domain (catch-all).
 /// "*.example.com" matches "api.example.com" but not "example.com".
 /// "example.com" matches exactly "example.com".
-fn domain_matches(pattern: &str, domain: &str) -> bool {
+pub(crate) fn domain_matches(pattern: &str, domain: &str) -> bool {
     if pattern == "*" {
         true
     } else if let Some(suffix) = pattern.strip_prefix("*.") {

--- a/crates/shuru-proxy/src/lib.rs
+++ b/crates/shuru-proxy/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 mod device;
 mod dns;
 mod proxy;
+mod secrets;
 mod stack;
 mod stream;
 mod tls;

--- a/crates/shuru-proxy/src/lib.rs
+++ b/crates/shuru-proxy/src/lib.rs
@@ -5,6 +5,7 @@ mod proxy;
 mod secrets;
 mod stack;
 mod stream;
+mod substitute;
 mod tls;
 
 pub use config::ProxyConfig;

--- a/crates/shuru-proxy/src/proxy.rs
+++ b/crates/shuru-proxy/src/proxy.rs
@@ -6,10 +6,11 @@ use boring::ssl::{SslConnector, SslMethod};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::config::ProxyConfig;
 use crate::dns;
+use crate::secrets::SecretResolver;
 use crate::stack::{ConnectionId, StackCommand, StackEvent, TcpConnection};
 use crate::stream::ChannelStream;
 use crate::tls::CertificateAuthority;
@@ -28,7 +29,7 @@ pub struct ProxyEngine {
     event_rx: mpsc::UnboundedReceiver<StackEvent>,
     cmd_tx: mpsc::UnboundedSender<StackCommand>,
     connections: HashMap<ConnectionId, mpsc::UnboundedSender<Vec<u8>>>,
-    placeholders: Arc<HashMap<String, String>>,
+    secrets: Arc<SecretResolver>,
     ca: Arc<tokio::sync::Mutex<CertificateAuthority>>,
     upstream_ssl: SslConnector,
     allowed_ips: AllowedIps,
@@ -49,12 +50,15 @@ impl ProxyEngine {
         builder.set_alpn_protos(b"\x08http/1.1").expect("ALPN");
         let upstream_ssl = builder.build();
 
+        let config = Arc::new(config);
+        let secrets = Arc::new(SecretResolver::new(config.clone(), placeholders));
+
         ProxyEngine {
-            config: Arc::new(config),
+            config,
             event_rx,
             cmd_tx,
             connections: HashMap::new(),
-            placeholders: Arc::new(placeholders),
+            secrets,
             ca: Arc::new(tokio::sync::Mutex::new(ca)),
             upstream_ssl,
             allowed_ips,
@@ -98,7 +102,7 @@ impl ProxyEngine {
         let cmd_tx = self.cmd_tx.clone();
         let config = self.config.clone();
         let ca = self.ca.clone();
-        let placeholders = self.placeholders.clone();
+        let secrets = self.secrets.clone();
         let upstream_ssl = self.upstream_ssl.clone();
         let allowed_ips = self.allowed_ips.clone();
 
@@ -110,7 +114,7 @@ impl ProxyEngine {
                 cmd_tx,
                 &config,
                 ca,
-                &placeholders,
+                &secrets,
                 upstream_ssl,
                 &allowed_ips,
             )
@@ -130,7 +134,7 @@ async fn handle_connection(
     cmd_tx: mpsc::UnboundedSender<StackCommand>,
     config: &ProxyConfig,
     ca: Arc<tokio::sync::Mutex<CertificateAuthority>>,
-    placeholders: &HashMap<String, String>,
+    secrets: &SecretResolver,
     upstream_ssl: SslConnector,
     allowed_ips: &AllowedIps,
 ) -> anyhow::Result<()> {
@@ -226,7 +230,18 @@ async fn handle_connection(
         }
 
         if let Some(domain) = sni {
-            let substitutions = config.secrets_for_domain(&domain, placeholders);
+            // Resolved per connection, so a rotated secret is picked up by the
+            // next connection to the domain without the guest noticing.
+            let substitutions = match secrets.substitutions_for_domain(&domain).await {
+                Ok(substitutions) => substitutions,
+                Err(e) => {
+                    // Warn rather than debug: the guest only sees a dropped
+                    // TLS connection, so this is the sole account of why.
+                    warn!("TLS to {domain} blocked: {e:#}");
+                    let _ = cmd_tx.send(StackCommand::Close { id });
+                    return Err(e.context(format!("TLS to {domain} blocked")));
+                }
+            };
             if !substitutions.is_empty() {
                 debug!("MITM: {domain}");
                 return handle_mitm(

--- a/crates/shuru-proxy/src/proxy.rs
+++ b/crates/shuru-proxy/src/proxy.rs
@@ -13,8 +13,13 @@ use crate::dns;
 use crate::secrets::SecretResolver;
 use crate::stack::{ConnectionId, StackCommand, StackEvent, TcpConnection};
 use crate::stream::ChannelStream;
+use crate::substitute::RequestStream;
 use crate::tls::CertificateAuthority;
 use crate::AllowedIps;
+
+/// How often a live relay re-resolves its secrets, so a rotation reaches a
+/// long-lived connection without waiting for it to reconnect.
+const SECRET_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// The async proxy engine.
 ///
@@ -114,7 +119,7 @@ impl ProxyEngine {
                 cmd_tx,
                 &config,
                 ca,
-                &secrets,
+                secrets,
                 upstream_ssl,
                 &allowed_ips,
             )
@@ -134,7 +139,7 @@ async fn handle_connection(
     cmd_tx: mpsc::UnboundedSender<StackCommand>,
     config: &ProxyConfig,
     ca: Arc<tokio::sync::Mutex<CertificateAuthority>>,
-    secrets: &SecretResolver,
+    secrets: Arc<SecretResolver>,
     upstream_ssl: SslConnector,
     allowed_ips: &AllowedIps,
 ) -> anyhow::Result<()> {
@@ -252,6 +257,7 @@ async fn handle_connection(
                     data_rx,
                     cmd_tx,
                     ca,
+                    secrets,
                     substitutions,
                     upstream_ssl,
                 )
@@ -333,6 +339,7 @@ async fn handle_mitm(
     data_rx: mpsc::UnboundedReceiver<Vec<u8>>,
     cmd_tx: mpsc::UnboundedSender<StackCommand>,
     ca: Arc<tokio::sync::Mutex<CertificateAuthority>>,
+    secrets: Arc<SecretResolver>,
     substitutions: Vec<(String, String)>,
     upstream_ssl: SslConnector,
 ) -> anyhow::Result<()> {
@@ -359,15 +366,34 @@ async fn handle_mitm(
 
     let guest_to_upstream = async move {
         let mut buf = vec![0u8; 65536];
+        let mut requests = RequestStream::new(substitutions);
+        let mut last_refresh = std::time::Instant::now();
+
         loop {
             match guest_rd.read(&mut buf).await {
-                Ok(0) | Err(_) => break,
-                Ok(n) => {
-                    let mut data = buf[..n].to_vec();
-                    for (placeholder, real_value) in &substitutions {
-                        data = replace_bytes(&data, placeholder.as_bytes(), real_value.as_bytes());
+                Ok(0) | Err(_) => {
+                    // A head held here belongs to a request the guest
+                    // abandoned. Forward it rather than swallow it.
+                    let pending = requests.take_pending();
+                    if !pending.is_empty() {
+                        let _ = upstream_wr.write_all(&pending).await;
                     }
-                    if upstream_wr.write_all(&data).await.is_err() {
+                    break;
+                }
+                Ok(n) => {
+                    // Pick up a rotated secret without waiting for the guest
+                    // to open a new connection. Cheap while the cached value
+                    // is live; a re-mint costs this connection what it would
+                    // have cost at connection setup.
+                    if !requests.is_tunnel() && last_refresh.elapsed() >= SECRET_REFRESH_INTERVAL {
+                        if let Ok(fresh) = secrets.substitutions_for_domain(&domain).await {
+                            requests.update(fresh);
+                        }
+                        last_refresh = std::time::Instant::now();
+                    }
+
+                    let out = requests.push(&buf[..n]);
+                    if !out.is_empty() && upstream_wr.write_all(&out).await.is_err() {
                         break;
                     }
                 }
@@ -396,30 +422,6 @@ async fn handle_mitm(
 
     let _ = cmd_tx.send(StackCommand::Close { id });
     Ok(())
-}
-
-/// Replace all occurrences of `from` with `to` in a byte slice.
-fn replace_bytes(data: &[u8], from: &[u8], to: &[u8]) -> Vec<u8> {
-    if from.is_empty() || data.len() < from.len() {
-        return data.to_vec();
-    }
-
-    let mut result = Vec::with_capacity(data.len());
-    let mut i = 0;
-
-    while i <= data.len() - from.len() {
-        if &data[i..i + from.len()] == from {
-            result.extend_from_slice(to);
-            i += from.len();
-        } else {
-            result.push(data[i]);
-            i += 1;
-        }
-    }
-
-    // Append remaining bytes that can't contain the pattern
-    result.extend_from_slice(&data[i..]);
-    result
 }
 
 /// Extract SNI from a TLS ClientHello.
@@ -504,23 +506,5 @@ mod tests {
     fn test_extract_sni_none_for_non_tls() {
         assert_eq!(extract_sni(b"GET / HTTP/1.1\r\n"), None);
         assert_eq!(extract_sni(&[]), None);
-    }
-
-    #[test]
-    fn test_replace_bytes() {
-        assert_eq!(
-            replace_bytes(b"hello world", b"world", b"rust"),
-            b"hello rust"
-        );
-        assert_eq!(
-            replace_bytes(
-                b"key=shuru_tok_abc123&other=val",
-                b"shuru_tok_abc123",
-                b"real_secret"
-            ),
-            b"key=real_secret&other=val"
-        );
-        assert_eq!(replace_bytes(b"no match", b"xyz", b"abc"), b"no match");
-        assert_eq!(replace_bytes(b"", b"x", b"y"), b"");
     }
 }

--- a/crates/shuru-proxy/src/secrets.rs
+++ b/crates/shuru-proxy/src/secrets.rs
@@ -1,0 +1,628 @@
+//! Resolution of secret values, including provider commands that mint short
+//! lived credentials and are re-run as those credentials expire.
+//!
+//! See docs/rfcs/0002-refreshable-secrets.md.
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+use tracing::warn;
+
+use crate::config::{ProxyConfig, SecretConfig};
+
+/// Re-mint a value once it comes within this long of expiring, so rotation
+/// happens ahead of the first request that would have failed.
+const REFRESH_WINDOW: Duration = Duration::from_secs(60);
+
+/// A provider that has not produced output in this long is killed.
+const PROVIDER_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Cap on provider stderr carried into an error message.
+const STDERR_LIMIT: usize = 4096;
+
+/// Resolves secrets to their real values for substitution.
+///
+/// Environment backed secrets are read on every call, which is free and keeps
+/// the pre-existing behaviour of picking up whatever the host env holds.
+/// Command backed secrets are cached until they approach expiry.
+pub struct SecretResolver {
+    config: Arc<ProxyConfig>,
+    placeholders: HashMap<String, String>,
+    cache: Mutex<HashMap<String, CacheEntry>>,
+}
+
+struct CacheEntry {
+    value: String,
+    /// None means the provider reported no expiry, so the value is permanent.
+    expires_at: Option<Instant>,
+}
+
+impl CacheEntry {
+    /// Usable without re-running the provider.
+    fn is_fresh(&self, now: Instant) -> bool {
+        match self.expires_at {
+            None => true,
+            Some(at) => now + REFRESH_WINDOW < at,
+        }
+    }
+
+    /// Past the refresh window but not yet dead, so still worth serving if a
+    /// refresh attempt fails.
+    fn is_usable(&self, now: Instant) -> bool {
+        match self.expires_at {
+            None => true,
+            Some(at) => now < at,
+        }
+    }
+}
+
+/// A value obtained from a provider command.
+struct Minted {
+    value: String,
+    expires_at: Option<Instant>,
+}
+
+/// The JSON a provider command writes to stdout.
+#[derive(Deserialize)]
+struct ProviderOutput {
+    version: u32,
+    value: String,
+    #[serde(default)]
+    expires_at: Option<String>,
+}
+
+impl SecretResolver {
+    pub fn new(config: Arc<ProxyConfig>, placeholders: HashMap<String, String>) -> Self {
+        Self {
+            config,
+            placeholders,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Placeholder to real value pairs for every secret bound to `domain`.
+    ///
+    /// Returns an error if a bound command backed secret cannot be resolved,
+    /// so the caller can fail the connection rather than forward a placeholder
+    /// that the upstream will reject with a confusing auth error.
+    pub async fn substitutions_for_domain(&self, domain: &str) -> Result<Vec<(String, String)>> {
+        let mut substitutions = Vec::new();
+        for (name, secret) in &self.config.secrets {
+            if !secret.matches_domain(domain) {
+                continue;
+            }
+            let Some(placeholder) = self.placeholders.get(name) else {
+                continue;
+            };
+            if let Some(value) = self.resolve(name, secret).await? {
+                substitutions.push((placeholder.clone(), value));
+            }
+        }
+        Ok(substitutions)
+    }
+
+    async fn resolve(&self, name: &str, secret: &SecretConfig) -> Result<Option<String>> {
+        if let Some(value) = &secret.value {
+            return Ok(Some(value.clone()));
+        }
+        if let Some(var) = &secret.from {
+            // A missing variable skips substitution rather than failing the
+            // connection, matching the behaviour before providers existed.
+            return Ok(std::env::var(var).ok());
+        }
+        match &secret.command {
+            Some(command) => self
+                .resolve_command(name, command, secret.ttl)
+                .await
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// Serve `name` from cache, running the provider when the cached value is
+    /// missing or near expiry.
+    ///
+    /// The cache lock is deliberately held across the provider run. That makes
+    /// concurrent connections to one expired secret wait on a single process
+    /// instead of each spawning their own.
+    async fn resolve_command(
+        &self,
+        name: &str,
+        command: &[String],
+        ttl: Option<Duration>,
+    ) -> Result<String> {
+        let mut cache = self.cache.lock().await;
+
+        if let Some(entry) = cache.get(name) {
+            if entry.is_fresh(Instant::now()) {
+                return Ok(entry.value.clone());
+            }
+        }
+
+        match run_provider(command, ttl, self.config.config_dir.as_deref()).await {
+            Ok(minted) => {
+                let value = minted.value.clone();
+                cache.insert(
+                    name.to_string(),
+                    CacheEntry {
+                        value: minted.value,
+                        expires_at: minted.expires_at,
+                    },
+                );
+                Ok(value)
+            }
+            Err(e) => {
+                if let Some(entry) = cache.get(name) {
+                    if entry.is_usable(Instant::now()) {
+                        warn!("secret '{name}': refresh failed, serving cached value: {e:#}");
+                        return Ok(entry.value.clone());
+                    }
+                }
+                Err(e.context(format!("resolving secret '{name}'")))
+            }
+        }
+    }
+}
+
+/// Run a provider command and parse what it minted.
+async fn run_provider(
+    command: &[String],
+    ttl: Option<Duration>,
+    cwd: Option<&std::path::Path>,
+) -> Result<Minted> {
+    let (program, args) = command
+        .split_first()
+        .ok_or_else(|| anyhow!("command is empty"))?;
+
+    let mut cmd = tokio::process::Command::new(program);
+    cmd.args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+    }
+
+    let output = tokio::time::timeout(PROVIDER_TIMEOUT, cmd.output())
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "'{program}' timed out after {}s",
+                PROVIDER_TIMEOUT.as_secs()
+            )
+        })?
+        .with_context(|| format!("running '{program}'"))?;
+
+    if !output.status.success() {
+        bail!(
+            "'{program}' exited with {}: {}",
+            output.status,
+            truncated_stderr(&output.stderr)
+        );
+    }
+
+    parse_provider_output(&output.stdout, ttl, Instant::now())
+        .with_context(|| format!("output of '{program}'"))
+}
+
+/// Parse provider stdout into a value and an absolute expiry.
+///
+/// `now` is taken by the caller so the expiry lands on the same clock reading
+/// used elsewhere in the resolve, and so tests can pin it.
+fn parse_provider_output(stdout: &[u8], ttl: Option<Duration>, now: Instant) -> Result<Minted> {
+    // Parse failures never quote stdout: it holds the credential.
+    let parsed: ProviderOutput =
+        serde_json::from_slice(stdout).map_err(|e| anyhow!("not valid JSON ({e})"))?;
+
+    if parsed.version != 1 {
+        bail!("unsupported version {}, expected 1", parsed.version);
+    }
+
+    let value = parsed.value.trim_end_matches(['\n', '\r']).to_string();
+    if value.is_empty() {
+        bail!("value is empty");
+    }
+
+    let expires_at = match parsed.expires_at {
+        Some(ref stamp) => Some(now + remaining_until(stamp)?),
+        None => ttl.map(|ttl| now + ttl),
+    };
+
+    Ok(Minted { value, expires_at })
+}
+
+/// Time left until an RFC3339 instant, as of now.
+fn remaining_until(stamp: &str) -> Result<Duration> {
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
+
+    let expires = OffsetDateTime::parse(stamp, &Rfc3339)
+        .map_err(|e| anyhow!("expires_at '{stamp}' is not RFC3339 ({e})"))?;
+    let remaining = expires - OffsetDateTime::now_utc();
+    if !remaining.is_positive() {
+        bail!("expires_at '{stamp}' is already in the past");
+    }
+    Ok(remaining.unsigned_abs())
+}
+
+fn truncated_stderr(stderr: &[u8]) -> String {
+    let text = String::from_utf8_lossy(stderr);
+    let text = text.trim();
+    if text.is_empty() {
+        return "<no stderr>".to_string();
+    }
+    match text.char_indices().nth(STDERR_LIMIT) {
+        Some((cut, _)) => format!("{}...", &text[..cut]),
+        None => text.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minted(json: &str, ttl: Option<Duration>) -> Result<Minted> {
+        parse_provider_output(json.as_bytes(), ttl, Instant::now())
+    }
+
+    #[test]
+    fn parses_value_and_expiry() {
+        let far_future = "2099-01-01T00:00:00Z";
+        let out = minted(
+            &format!(r#"{{"version":1,"value":"ghs_abc","expires_at":"{far_future}"}}"#),
+            None,
+        )
+        .unwrap();
+        assert_eq!(out.value, "ghs_abc");
+        assert!(out.expires_at.is_some());
+    }
+
+    #[test]
+    fn trailing_newline_is_trimmed() {
+        let out = minted(r#"{"version":1,"value":"ghs_abc\n"}"#, None).unwrap();
+        assert_eq!(out.value, "ghs_abc");
+    }
+
+    #[test]
+    fn expiry_falls_back_to_ttl_then_to_never() {
+        let with_ttl = minted(
+            r#"{"version":1,"value":"v"}"#,
+            Some(Duration::from_secs(600)),
+        )
+        .unwrap();
+        assert!(with_ttl.expires_at.is_some());
+
+        let without_ttl = minted(r#"{"version":1,"value":"v"}"#, None).unwrap();
+        assert!(without_ttl.expires_at.is_none());
+    }
+
+    #[test]
+    fn reported_expiry_wins_over_ttl() {
+        // A ttl of an hour against a reported expiry a few seconds out: the
+        // reported one must win, so the entry is already inside the window.
+        let soon = time::OffsetDateTime::now_utc() + time::Duration::seconds(5);
+        let stamp = soon
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+        let now = Instant::now();
+        let out = parse_provider_output(
+            format!(r#"{{"version":1,"value":"v","expires_at":"{stamp}"}}"#).as_bytes(),
+            Some(Duration::from_secs(3600)),
+            now,
+        )
+        .unwrap();
+        assert!(out.expires_at.unwrap() < now + Duration::from_secs(60));
+    }
+
+    #[test]
+    fn rejects_bad_output() {
+        assert!(minted(r#"{"version":2,"value":"v"}"#, None).is_err());
+        assert!(minted(r#"{"version":1,"value":""}"#, None).is_err());
+        assert!(minted(r#"{"version":1}"#, None).is_err());
+        assert!(minted("not json at all", None).is_err());
+        assert!(minted(
+            r#"{"version":1,"value":"v","expires_at":"yesterday"}"#,
+            None
+        )
+        .is_err());
+        assert!(minted(
+            r#"{"version":1,"value":"v","expires_at":"2000-01-01T00:00:00Z"}"#,
+            None
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn parse_error_never_quotes_stdout() {
+        let secret = "ghs_supersecretvalue";
+        // `.err()` rather than `unwrap_err()`: Minted has no Debug impl, by
+        // design, so a credential cannot reach a panic message.
+        let err = minted(&format!(r#"{{"version":9,"value":"{secret}"}}"#), None)
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(!err.contains(secret), "error leaked the credential: {err}");
+    }
+
+    #[test]
+    fn cache_entry_freshness() {
+        let now = Instant::now();
+
+        let permanent = CacheEntry {
+            value: "v".into(),
+            expires_at: None,
+        };
+        assert!(permanent.is_fresh(now) && permanent.is_usable(now));
+
+        let inside_window = CacheEntry {
+            value: "v".into(),
+            expires_at: Some(now + Duration::from_secs(30)),
+        };
+        assert!(!inside_window.is_fresh(now));
+        assert!(inside_window.is_usable(now));
+
+        let dead = CacheEntry {
+            value: "v".into(),
+            expires_at: Some(now - Duration::from_secs(1)),
+        };
+        assert!(!dead.is_fresh(now) && !dead.is_usable(now));
+
+        let healthy = CacheEntry {
+            value: "v".into(),
+            expires_at: Some(now + Duration::from_secs(3600)),
+        };
+        assert!(healthy.is_fresh(now));
+    }
+
+    /// A provider script plus the file it records its call count in.
+    struct TestProvider {
+        dir: std::path::PathBuf,
+        script: std::path::PathBuf,
+        counter: std::path::PathBuf,
+    }
+
+    impl TestProvider {
+        fn new(body: &str) -> Self {
+            use std::sync::atomic::{AtomicU32, Ordering};
+            static SEQ: AtomicU32 = AtomicU32::new(0);
+
+            let dir = std::env::temp_dir().join(format!(
+                "shuru-secrets-{}-{}",
+                std::process::id(),
+                SEQ.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+
+            let script = dir.join("provider.sh");
+            std::fs::write(&script, body).unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+            }
+
+            Self {
+                counter: dir.join("count"),
+                script,
+                dir,
+            }
+        }
+
+        /// argv for a secret backed by this provider, minting values that
+        /// expire at `stamp`.
+        fn argv(&self, stamp: &str) -> Vec<String> {
+            vec![
+                self.script.to_str().unwrap().to_string(),
+                self.counter.to_str().unwrap().to_string(),
+                stamp.to_string(),
+            ]
+        }
+
+        fn calls(&self) -> u32 {
+            std::fs::read_to_string(&self.counter)
+                .map(|s| s.trim().parse().unwrap())
+                .unwrap_or(0)
+        }
+    }
+
+    impl Drop for TestProvider {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    /// Mints token-N on the Nth call, expiring at the stamp in argv.
+    const COUNTING_PROVIDER: &str = r#"#!/bin/sh
+n=$(cat "$1" 2>/dev/null || echo 0)
+n=$((n + 1))
+printf '%s' "$n" > "$1"
+printf '{"version":1,"value":"token-%s","expires_at":"%s"}' "$n" "$2"
+"#;
+
+    /// Succeeds once, then fails every later call.
+    const FAILS_AFTER_FIRST: &str = r#"#!/bin/sh
+n=$(cat "$1" 2>/dev/null || echo 0)
+n=$((n + 1))
+printf '%s' "$n" > "$1"
+if [ "$n" -gt 1 ]; then
+  echo "mint failed" >&2
+  exit 1
+fi
+printf '{"version":1,"value":"token-%s","expires_at":"%s"}' "$n" "$2"
+"#;
+
+    const ALWAYS_FAILS: &str = r#"#!/bin/sh
+echo "no credentials available" >&2
+exit 1
+"#;
+
+    /// Far enough out to stay fresh for the whole test.
+    const STABLE: &str = "2099-01-01T00:00:00Z";
+
+    /// Inside the refresh window, so every resolve re-mints.
+    fn expiring_soon() -> String {
+        let soon = time::OffsetDateTime::now_utc() + time::Duration::seconds(30);
+        soon.format(&time::format_description::well_known::Rfc3339)
+            .unwrap()
+    }
+
+    fn resolver_for(secret: SecretConfig) -> SecretResolver {
+        let mut config = ProxyConfig::default();
+        config.secrets.insert("TOKEN".to_string(), secret);
+        let placeholders =
+            HashMap::from([("TOKEN".to_string(), "shuru_tok_placeholder".to_string())]);
+        SecretResolver::new(Arc::new(config), placeholders)
+    }
+
+    async fn resolve_one(resolver: &SecretResolver, domain: &str) -> Result<Vec<(String, String)>> {
+        resolver.substitutions_for_domain(domain).await
+    }
+
+    #[tokio::test]
+    async fn fresh_value_is_served_from_cache() {
+        let provider = TestProvider::new(COUNTING_PROVIDER);
+        let resolver = resolver_for(SecretConfig::from_command(
+            provider.argv(STABLE),
+            vec!["api.github.com".into()],
+        ));
+
+        let first = resolve_one(&resolver, "api.github.com").await.unwrap();
+        let second = resolve_one(&resolver, "api.github.com").await.unwrap();
+
+        assert_eq!(
+            first,
+            vec![("shuru_tok_placeholder".into(), "token-1".into())]
+        );
+        assert_eq!(second, first);
+        assert_eq!(provider.calls(), 1, "cached value should not re-run");
+    }
+
+    #[tokio::test]
+    async fn value_near_expiry_is_reminted() {
+        let provider = TestProvider::new(COUNTING_PROVIDER);
+        let resolver = resolver_for(SecretConfig::from_command(
+            provider.argv(&expiring_soon()),
+            vec!["api.github.com".into()],
+        ));
+
+        let first = resolve_one(&resolver, "api.github.com").await.unwrap();
+        let second = resolve_one(&resolver, "api.github.com").await.unwrap();
+
+        assert_eq!(first[0].1, "token-1");
+        assert_eq!(second[0].1, "token-2");
+        assert_eq!(first[0].0, second[0].0, "placeholder must not change");
+        assert_eq!(provider.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_resolves_mint_once() {
+        let provider = TestProvider::new(COUNTING_PROVIDER);
+        let resolver = Arc::new(resolver_for(SecretConfig::from_command(
+            provider.argv(STABLE),
+            vec!["api.github.com".into()],
+        )));
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let resolver = resolver.clone();
+            tasks.push(tokio::spawn(async move {
+                resolver
+                    .substitutions_for_domain("api.github.com")
+                    .await
+                    .unwrap()
+            }));
+        }
+        for task in tasks {
+            assert_eq!(task.await.unwrap()[0].1, "token-1");
+        }
+
+        assert_eq!(
+            provider.calls(),
+            1,
+            "single flight should collapse the burst"
+        );
+    }
+
+    #[tokio::test]
+    async fn failing_provider_fails_closed() {
+        let provider = TestProvider::new(ALWAYS_FAILS);
+        let resolver = resolver_for(SecretConfig::from_command(
+            provider.argv(STABLE),
+            vec!["api.github.com".into()],
+        ));
+
+        let err = resolve_one(&resolver, "api.github.com")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("TOKEN"), "error should name the secret: {err}");
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_falls_back_to_a_live_cached_value() {
+        let provider = TestProvider::new(FAILS_AFTER_FIRST);
+        let resolver = resolver_for(SecretConfig::from_command(
+            provider.argv(&expiring_soon()),
+            vec!["api.github.com".into()],
+        ));
+
+        let first = resolve_one(&resolver, "api.github.com").await.unwrap();
+        let second = resolve_one(&resolver, "api.github.com").await.unwrap();
+
+        assert_eq!(first[0].1, "token-1");
+        assert_eq!(second[0].1, "token-1", "should serve the still-live value");
+        assert_eq!(provider.calls(), 2, "refresh should have been attempted");
+    }
+
+    #[tokio::test]
+    async fn unbound_domain_never_runs_the_provider() {
+        let provider = TestProvider::new(COUNTING_PROVIDER);
+        let resolver = resolver_for(SecretConfig::from_command(
+            provider.argv(STABLE),
+            vec!["api.github.com".into()],
+        ));
+
+        assert!(resolve_one(&resolver, "evil.example.com")
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(provider.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_env_var_skips_substitution() {
+        let resolver = resolver_for(SecretConfig::from_env(
+            "SHURU_TEST_VAR_THAT_DOES_NOT_EXIST",
+            vec!["api.openai.com".into()],
+        ));
+
+        assert!(resolve_one(&resolver, "api.openai.com")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_command_is_an_error_not_a_panic() {
+        let resolver = resolver_for(SecretConfig::from_command(
+            Vec::new(),
+            vec!["api.github.com".into()],
+        ));
+        assert!(resolve_one(&resolver, "api.github.com").await.is_err());
+    }
+
+    #[test]
+    fn stderr_is_truncated() {
+        let long = "x".repeat(STDERR_LIMIT * 2);
+        let out = truncated_stderr(long.as_bytes());
+        assert!(out.ends_with("..."));
+        assert!(out.len() < long.len());
+        assert_eq!(truncated_stderr(b"  "), "<no stderr>");
+    }
+}

--- a/crates/shuru-proxy/src/substitute.rs
+++ b/crates/shuru-proxy/src/substitute.rs
@@ -1,0 +1,614 @@
+//! Rewriting of the guest to upstream request stream.
+//!
+//! Substitution is scoped to the request head: the request line and every
+//! header value, whatever it is named. Bodies stream through untouched.
+//!
+//! That scope is what makes this deterministic. At an arbitrary byte offset,
+//! "no more bytes yet" and "the request ended" are indistinguishable without
+//! a clock. A head that has not reached its terminating CRLF CRLF is
+//! unambiguously an unfinished request, so holding it is correct rather than
+//! a guess, and the upstream is waiting on those bytes anyway.
+//!
+//! Framing is read, never rewritten. It is needed only to find where a body
+//! ends and the next head begins on a reused connection. An intermediary that
+//! never re-frames cannot desynchronise its upstream by re-framing wrongly,
+//! so the request smuggling exposure of a rewriting proxy does not arise.
+//! Anything ambiguous degrades to a plain byte tunnel.
+//!
+//! See docs/rfcs/0002-refreshable-secrets.md.
+
+/// Cap on a single request head. A head larger than this is tunnelled rather
+/// than buffered without bound.
+const MAX_HEAD: usize = 64 * 1024;
+
+const HEAD_END: &[u8] = b"\r\n\r\n";
+
+/// Replace all occurrences of `from` with `to` in a byte slice.
+pub(crate) fn replace_bytes(data: &[u8], from: &[u8], to: &[u8]) -> Vec<u8> {
+    if from.is_empty() || data.len() < from.len() {
+        return data.to_vec();
+    }
+
+    let mut result = Vec::with_capacity(data.len());
+    let mut i = 0;
+
+    while i <= data.len() - from.len() {
+        if &data[i..i + from.len()] == from {
+            result.extend_from_slice(to);
+            i += from.len();
+        } else {
+            result.push(data[i]);
+            i += 1;
+        }
+    }
+
+    result.extend_from_slice(&data[i..]);
+    result
+}
+
+/// How the body of the request being read is delimited.
+enum Body {
+    /// A known number of bytes remain.
+    Exact(u64),
+    /// Chunked, tracked only closely enough to find where it ends.
+    Chunked(Chunked),
+}
+
+enum Chunked {
+    /// Reading a chunk size line, which may carry extensions after a `;`.
+    Size(Vec<u8>),
+    /// Passing through chunk data.
+    Data(u64),
+    /// Consuming the CRLF that follows chunk data.
+    DataEnd,
+    /// After the zero chunk, reading trailers until a blank line.
+    Trailer(Vec<u8>),
+}
+
+enum State {
+    /// Accumulating a request head.
+    Head,
+    /// Forwarding a body.
+    Body(Body),
+    /// Forwarding everything unchanged for the rest of the connection.
+    Tunnel,
+}
+
+/// Framing derived from a head, per RFC 9112 section 6.3.
+enum Framing {
+    None,
+    Exact(u64),
+    Chunked,
+    /// Unparseable, self contradictory, or not plain HTTP from here on.
+    Ambiguous,
+}
+
+/// Substitutes secrets into request heads on a guest to upstream stream.
+pub(crate) struct RequestStream {
+    /// Placeholder to real value, both as raw bytes.
+    pairs: Vec<(Vec<u8>, Vec<u8>)>,
+    state: State,
+    head: Vec<u8>,
+}
+
+impl RequestStream {
+    pub(crate) fn new(substitutions: Vec<(String, String)>) -> Self {
+        Self {
+            pairs: Self::to_pairs(substitutions),
+            state: State::Head,
+            head: Vec::new(),
+        }
+    }
+
+    fn to_pairs(substitutions: Vec<(String, String)>) -> Vec<(Vec<u8>, Vec<u8>)> {
+        substitutions
+            .into_iter()
+            .map(|(placeholder, value)| (placeholder.into_bytes(), value.into_bytes()))
+            .collect()
+    }
+
+    /// Swap in freshly resolved values, applied from the next head onwards.
+    pub(crate) fn update(&mut self, substitutions: Vec<(String, String)>) {
+        self.pairs = Self::to_pairs(substitutions);
+    }
+
+    /// True once this connection has stopped interpreting HTTP, so the caller
+    /// can skip work it no longer needs to do.
+    pub(crate) fn is_tunnel(&self) -> bool {
+        matches!(self.state, State::Tunnel)
+    }
+
+    /// Consume a chunk of guest bytes, returning what to forward upstream.
+    ///
+    /// Returns fewer bytes than it was given only while a head is incomplete,
+    /// which is precisely when the request is unfinished.
+    pub(crate) fn push(&mut self, chunk: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(chunk.len());
+        let mut pos = 0;
+
+        while pos < chunk.len() {
+            match &mut self.state {
+                State::Tunnel => {
+                    out.extend_from_slice(&chunk[pos..]);
+                    pos = chunk.len();
+                }
+                State::Body(body) => {
+                    let (taken, finished) = body.consume(&chunk[pos..]);
+                    out.extend_from_slice(&chunk[pos..pos + taken]);
+                    pos += taken;
+                    if finished {
+                        self.state = State::Head;
+                    } else if taken == 0 {
+                        // Framing stopped making sense mid-body.
+                        self.state = State::Tunnel;
+                    }
+                }
+                State::Head => {
+                    let rest = &chunk[pos..];
+                    match head_end(&self.head, rest) {
+                        Some(end) => {
+                            self.head.extend_from_slice(&rest[..end]);
+                            pos += end;
+                            let head = std::mem::take(&mut self.head);
+                            let rewritten = self.finish_head(head);
+                            out.extend_from_slice(&rewritten);
+                        }
+                        None => {
+                            self.head.extend_from_slice(rest);
+                            pos = chunk.len();
+                            if self.head.len() > MAX_HEAD {
+                                // Never buffer without bound: give up on
+                                // interpreting this connection.
+                                out.extend_from_slice(&std::mem::take(&mut self.head));
+                                self.state = State::Tunnel;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        out
+    }
+
+    /// Anything still held when the guest stops sending. A partial head here
+    /// means the request was abandoned, so forward it rather than eat it.
+    pub(crate) fn take_pending(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.head)
+    }
+
+    /// Substitute into a complete head and set the state for its body.
+    fn finish_head(&mut self, head: Vec<u8>) -> Vec<u8> {
+        // Classify before substituting, so framing is read from what the
+        // guest actually sent.
+        self.state = match classify(&head) {
+            Framing::None => State::Head,
+            Framing::Exact(n) => State::Body(Body::Exact(n)),
+            Framing::Chunked => State::Body(Body::Chunked(Chunked::Size(Vec::new()))),
+            Framing::Ambiguous => State::Tunnel,
+        };
+
+        let mut out = head;
+        for (from, to) in &self.pairs {
+            out = replace_bytes(&out, from, to);
+        }
+        out
+    }
+}
+
+impl Body {
+    /// Returns how many leading bytes of `data` belong to this body, and
+    /// whether the body ended within them.
+    fn consume(&mut self, data: &[u8]) -> (usize, bool) {
+        match self {
+            Body::Exact(remaining) => {
+                let take = (*remaining).min(data.len() as u64) as usize;
+                *remaining -= take as u64;
+                (take, *remaining == 0)
+            }
+            Body::Chunked(chunked) => chunked.consume(data),
+        }
+    }
+}
+
+impl Chunked {
+    fn consume(&mut self, data: &[u8]) -> (usize, bool) {
+        let mut pos = 0;
+        while pos < data.len() {
+            match self {
+                Chunked::Size(line) => {
+                    let rest = &data[pos..];
+                    match rest.iter().position(|b| *b == b'\n') {
+                        Some(i) => {
+                            line.extend_from_slice(&rest[..=i]);
+                            pos += i + 1;
+                            let size = parse_chunk_size(line);
+                            line.clear();
+                            match size {
+                                Some(0) => *self = Chunked::Trailer(Vec::new()),
+                                Some(n) => *self = Chunked::Data(n),
+                                // An unreadable size line means the framing is
+                                // no longer trustworthy.
+                                None => return (pos, false),
+                            }
+                        }
+                        None => {
+                            line.extend_from_slice(rest);
+                            pos = data.len();
+                        }
+                    }
+                }
+                Chunked::Data(remaining) => {
+                    let take = (*remaining).min((data.len() - pos) as u64) as usize;
+                    *remaining -= take as u64;
+                    pos += take;
+                    if *remaining == 0 {
+                        *self = Chunked::DataEnd;
+                    }
+                }
+                Chunked::DataEnd => {
+                    // Skip the CRLF terminating chunk data.
+                    if data[pos] == b'\n' {
+                        *self = Chunked::Size(Vec::new());
+                    }
+                    pos += 1;
+                }
+                Chunked::Trailer(line) => {
+                    let rest = &data[pos..];
+                    match rest.iter().position(|b| *b == b'\n') {
+                        Some(i) => {
+                            line.extend_from_slice(&rest[..=i]);
+                            pos += i + 1;
+                            let blank = line
+                                .iter()
+                                .all(|b| matches!(b, b'\r' | b'\n' | b' ' | b'\t'));
+                            line.clear();
+                            if blank {
+                                return (pos, true);
+                            }
+                        }
+                        None => {
+                            line.extend_from_slice(rest);
+                            pos = data.len();
+                        }
+                    }
+                }
+            }
+        }
+        (pos, false)
+    }
+}
+
+/// Chunk size is hex, optionally followed by `;` extensions.
+fn parse_chunk_size(line: &[u8]) -> Option<u64> {
+    let digits: Vec<u8> = line
+        .iter()
+        .copied()
+        .skip_while(|b| matches!(b, b' ' | b'\t'))
+        .take_while(|b| b.is_ascii_hexdigit())
+        .collect();
+    if digits.is_empty() {
+        return None;
+    }
+    u64::from_str_radix(std::str::from_utf8(&digits).ok()?, 16).ok()
+}
+
+/// Index in `hay` just past a CRLF CRLF, which may have started in `prev`.
+fn head_end(prev: &[u8], hay: &[u8]) -> Option<usize> {
+    let back = prev.len().min(HEAD_END.len() - 1);
+    if back > 0 {
+        let mut probe = Vec::with_capacity(back + HEAD_END.len() - 1);
+        probe.extend_from_slice(&prev[prev.len() - back..]);
+        probe.extend_from_slice(&hay[..hay.len().min(HEAD_END.len() - 1)]);
+        for start in 0..back {
+            if probe.len() >= start + HEAD_END.len()
+                && &probe[start..start + HEAD_END.len()] == HEAD_END
+            {
+                return Some(start + HEAD_END.len() - back);
+            }
+        }
+    }
+    hay.windows(HEAD_END.len())
+        .position(|w| w == HEAD_END)
+        .map(|i| i + HEAD_END.len())
+}
+
+/// Derive body framing from a head, following RFC 9112 section 6.3.
+///
+/// Anything the specification calls out as a possible smuggling attempt is
+/// reported ambiguous rather than resolved, since this proxy has no need to
+/// forward such a message as HTTP.
+fn classify(head: &[u8]) -> Framing {
+    let mut headers = [httparse::EMPTY_HEADER; 96];
+    let mut req = httparse::Request::new(&mut headers);
+    if !matches!(req.parse(head), Ok(httparse::Status::Complete(_))) {
+        return Framing::Ambiguous;
+    }
+
+    // CONNECT stops being HTTP after this exchange.
+    if req.method.map(|m| m.eq_ignore_ascii_case("CONNECT")) == Some(true) {
+        return Framing::Ambiguous;
+    }
+
+    let mut content_length: Option<u64> = None;
+    let mut conflicting_length = false;
+    let mut chunked = false;
+    let mut has_transfer_encoding = false;
+    let mut upgrade = false;
+
+    for header in req.headers.iter() {
+        if header.name.eq_ignore_ascii_case("transfer-encoding") {
+            has_transfer_encoding = true;
+            let value = String::from_utf8_lossy(header.value).to_ascii_lowercase();
+            // Only chunked as the final coding gives a length we can follow.
+            chunked = value.rsplit(',').next().map(str::trim) == Some("chunked");
+        } else if header.name.eq_ignore_ascii_case("content-length") {
+            let parsed = std::str::from_utf8(header.value)
+                .ok()
+                .map(str::trim)
+                .and_then(|v| v.parse::<u64>().ok());
+            match (parsed, content_length) {
+                (None, _) => conflicting_length = true,
+                (Some(n), Some(seen)) if n != seen => conflicting_length = true,
+                (Some(n), _) => content_length = Some(n),
+            }
+        } else if header.name.eq_ignore_ascii_case("upgrade") {
+            upgrade = true;
+        }
+    }
+
+    if upgrade || conflicting_length {
+        return Framing::Ambiguous;
+    }
+    if has_transfer_encoding {
+        // Both fields present is called out as a possible smuggling attempt,
+        // and a non-chunked coding leaves no length to follow.
+        if content_length.is_some() || !chunked {
+            return Framing::Ambiguous;
+        }
+        return Framing::Chunked;
+    }
+    match content_length {
+        Some(0) | None => Framing::None,
+        Some(n) => Framing::Exact(n),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PLACEHOLDER: &str = "shuru_tok_abc123";
+    const SECRET: &str = "sk-a-much-longer-real-secret-value";
+
+    fn stream() -> RequestStream {
+        RequestStream::new(vec![(PLACEHOLDER.to_string(), SECRET.to_string())])
+    }
+
+    /// Feed `input` in slices of `size`, returning everything forwarded.
+    fn feed(s: &mut RequestStream, input: &[u8], size: usize) -> Vec<u8> {
+        let mut out = Vec::new();
+        for piece in input.chunks(size.max(1)) {
+            out.extend(s.push(piece));
+        }
+        out
+    }
+
+    fn get_request() -> String {
+        format!("GET /v1/models HTTP/1.1\r\nHost: api.openai.com\r\nAuthorization: Bearer {PLACEHOLDER}\r\n\r\n")
+    }
+
+    #[test]
+    fn substitutes_in_any_header_not_a_fixed_list() {
+        for name in [
+            "Authorization",
+            "X-Api-Key",
+            "x-goog-api-key",
+            "X-Some-Vendor-Nobody-Has-Heard-Of",
+        ] {
+            let req = format!("GET / HTTP/1.1\r\nHost: h\r\n{name}: {PLACEHOLDER}\r\n\r\n");
+            let out = stream().push(req.as_bytes());
+            assert_eq!(
+                String::from_utf8(out).unwrap(),
+                req.replace(PLACEHOLDER, SECRET),
+                "header {name} was not substituted"
+            );
+        }
+    }
+
+    #[test]
+    fn substitutes_in_the_request_line() {
+        let req = format!(
+            "GET /v1?key={PLACEHOLDER}&x=1 HTTP/1.1\r\nHost: generativelanguage.googleapis.com\r\n\r\n"
+        );
+        let out = stream().push(req.as_bytes());
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            req.replace(PLACEHOLDER, SECRET)
+        );
+    }
+
+    #[test]
+    fn substitutes_at_every_split_point() {
+        let req = get_request();
+        let expected = req.replace(PLACEHOLDER, SECRET);
+        for size in 1..=req.len() {
+            let mut s = stream();
+            let mut out = feed(&mut s, req.as_bytes(), size);
+            out.extend(s.take_pending());
+            assert_eq!(
+                String::from_utf8(out).unwrap(),
+                expected,
+                "lost substitution at chunk size {size}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_body_is_forwarded_untouched_even_if_it_holds_a_placeholder() {
+        let body = format!("tok={PLACEHOLDER}");
+        let req = format!(
+            "POST /p HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer {PLACEHOLDER}\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut s = stream();
+        let out = String::from_utf8(feed(&mut s, req.as_bytes(), 7)).unwrap();
+
+        // Header substituted, body byte for byte identical, so the declared
+        // Content-Length stays true.
+        assert!(out.contains(&format!("Authorization: Bearer {SECRET}")));
+        assert!(out.ends_with(&body));
+        assert_eq!(out.len(), req.len() - PLACEHOLDER.len() + SECRET.len());
+    }
+
+    #[test]
+    fn second_request_on_a_reused_connection_is_substituted() {
+        let body = "0123456789";
+        let first = format!(
+            "POST /p HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer {PLACEHOLDER}\r\nContent-Length: 10\r\n\r\n{body}"
+        );
+        let both = format!("{first}{}", get_request());
+
+        for size in [1, 3, 17, 64, 4096] {
+            let mut s = stream();
+            let out = String::from_utf8(feed(&mut s, both.as_bytes(), size)).unwrap();
+            assert_eq!(
+                out.matches(SECRET).count(),
+                2,
+                "both heads should be substituted at chunk size {size}"
+            );
+            assert!(!out.contains(PLACEHOLDER));
+        }
+    }
+
+    #[test]
+    fn chunked_body_is_tracked_so_the_next_head_is_found() {
+        let first = format!(
+            "POST /p HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer {PLACEHOLDER}\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n3\r\nbye\r\n0\r\n\r\n"
+        );
+        let both = format!("{first}{}", get_request());
+
+        for size in [1, 2, 9, 128] {
+            let mut s = stream();
+            let out = String::from_utf8(feed(&mut s, both.as_bytes(), size)).unwrap();
+            assert_eq!(
+                out.matches(SECRET).count(),
+                2,
+                "chunked body mistracked at chunk size {size}"
+            );
+            assert!(out.contains("5\r\nhello\r\n"), "chunk data was altered");
+        }
+    }
+
+    #[test]
+    fn chunk_extensions_and_trailers_are_handled() {
+        let first = format!(
+            "POST /p HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer {PLACEHOLDER}\r\nTransfer-Encoding: chunked\r\n\r\n5;ext=1\r\nhello\r\n0\r\nX-Trailer: v\r\n\r\n"
+        );
+        let both = format!("{first}{}", get_request());
+        let mut s = stream();
+        let out = String::from_utf8(feed(&mut s, both.as_bytes(), 3)).unwrap();
+        assert_eq!(out.matches(SECRET).count(), 2);
+    }
+
+    #[test]
+    fn ambiguous_framing_degrades_to_a_tunnel() {
+        // Both Content-Length and Transfer-Encoding: RFC 9112 6.3 calls this
+        // out as a possible smuggling attempt.
+        let smuggle = format!(
+            "POST /p HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer {PLACEHOLDER}\r\nContent-Length: 6\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n{}",
+            get_request()
+        );
+        let mut s = stream();
+        let out = String::from_utf8(feed(&mut s, smuggle.as_bytes(), 11)).unwrap();
+
+        assert!(s.is_tunnel());
+        // The offending head is still substituted, but nothing after it is
+        // interpreted, so a smuggled second request is passed through as data.
+        assert_eq!(out.matches(SECRET).count(), 1);
+        assert!(
+            out.contains(PLACEHOLDER),
+            "tunnelled bytes must be verbatim"
+        );
+    }
+
+    #[test]
+    fn conflicting_content_lengths_degrade_to_a_tunnel() {
+        let req =
+            "POST /p HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\nContent-Length: 9\r\n\r\nhello";
+        let mut s = stream();
+        let out = feed(&mut s, req.as_bytes(), 5);
+        assert!(s.is_tunnel());
+        assert_eq!(out, req.as_bytes());
+    }
+
+    #[test]
+    fn upgrade_and_connect_degrade_to_a_tunnel() {
+        let ws = "GET /s HTTP/1.1\r\nHost: h\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n";
+        let mut s = stream();
+        let out = feed(&mut s, ws.as_bytes(), 6);
+        assert!(s.is_tunnel());
+        assert_eq!(out, ws.as_bytes());
+
+        let connect = "CONNECT h:443 HTTP/1.1\r\nHost: h\r\n\r\n";
+        let mut s = stream();
+        s.push(connect.as_bytes());
+        assert!(s.is_tunnel());
+    }
+
+    #[test]
+    fn an_oversized_head_is_tunnelled_not_buffered_forever() {
+        let mut s = stream();
+        let filler = format!("GET / HTTP/1.1\r\nX-Pad: {}\r\n", "A".repeat(MAX_HEAD));
+        let out = s.push(filler.as_bytes());
+        assert!(s.is_tunnel());
+        assert_eq!(out, filler.as_bytes(), "held bytes must be released intact");
+    }
+
+    #[test]
+    fn an_incomplete_head_is_held_and_released_on_close() {
+        let mut s = stream();
+        let partial = "GET / HTTP/1.1\r\nHost: h\r\n";
+        assert!(
+            s.push(partial.as_bytes()).is_empty(),
+            "an unfinished request must not be forwarded"
+        );
+        assert_eq!(s.take_pending(), partial.as_bytes());
+    }
+
+    #[test]
+    fn refreshed_values_apply_from_the_next_head() {
+        let mut s = stream();
+        let out = String::from_utf8(s.push(get_request().as_bytes())).unwrap();
+        assert!(out.contains(SECRET));
+
+        s.update(vec![(PLACEHOLDER.to_string(), "rotated-value".to_string())]);
+        let out = String::from_utf8(s.push(get_request().as_bytes())).unwrap();
+        assert!(out.contains("rotated-value"));
+    }
+
+    #[test]
+    fn no_substitutions_passes_bytes_through() {
+        let mut s = RequestStream::new(Vec::new());
+        let req = get_request();
+        assert_eq!(feed(&mut s, req.as_bytes(), 5), req.as_bytes());
+    }
+
+    #[test]
+    fn replace_bytes_basics() {
+        assert_eq!(
+            replace_bytes(b"hello world", b"world", b"rust"),
+            b"hello rust"
+        );
+        assert_eq!(replace_bytes(b"no match", b"xyz", b"abc"), b"no match");
+        assert_eq!(replace_bytes(b"", b"x", b"y"), b"");
+    }
+
+    #[test]
+    fn head_end_finds_a_terminator_split_across_reads() {
+        assert_eq!(head_end(b"", b"abc\r\n\r\ndef"), Some(7));
+        assert_eq!(head_end(b"abc\r\n", b"\r\ndef"), Some(2));
+        assert_eq!(head_end(b"abc\r\n\r", b"\ndef"), Some(1));
+        assert_eq!(head_end(b"abc", b"defg"), None);
+    }
+}

--- a/crates/shuru-sdk/Cargo.toml
+++ b/crates/shuru-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuru-sdk"
-version = "0.3.8"
+version = "0.4.0"
 edition = "2021"
 description = "Async Rust SDK for Shuru microVMs"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ cas = ["shuru-store", "blake3"]
 [dependencies]
 shuru-vm = { version = "0.3.8", path = "../shuru-vm" }
 shuru-proto = { version = "0.3.3", path = "../shuru-proto" }
-shuru-proxy = { version = "0.2.4", path = "../shuru-proxy" }
+shuru-proxy = { version = "0.3.0", path = "../shuru-proxy" }
 shuru-store = { version = "0.1.1", path = "../shuru-store", optional = true }
 tokio = { version = "1", features = ["sync"] }
 anyhow = "1"

--- a/docs/rfcs/0002-refreshable-secrets.md
+++ b/docs/rfcs/0002-refreshable-secrets.md
@@ -1,6 +1,6 @@
 # RFC 0002: Refreshable secrets
 
-- Status: Draft
+- Status: Implemented
 - Date: 2026-08-04
 - Scope: shuru-proxy, shuru-cli config, shuru-sdk public types
 - Issue: superhq-ai/shuru#40
@@ -9,19 +9,23 @@
 
 Let a secret be backed by a command instead of a host environment variable.
 The proxy runs that command to mint the real value, caches it in memory, and
-re-runs it when the value expires. The placeholder in the guest never changes,
+re-runs it as the value expires. The placeholder in the guest never changes,
 so a rotation is invisible inside the VM.
 
-This makes short lived credentials usable for long running sandbox work.
-The motivating case is a GitHub App installation token, which dies after one
-hour and currently strands any agent task that outlives it.
+This makes short lived credentials usable for long running sandbox work. The
+motivating case is a GitHub App installation token, which dies after one hour
+and currently strands any agent task that outlives it.
+
+It also narrows where substitution happens. Secrets are now substituted in the
+request head, meaning the request line and any header value, and no longer
+anywhere in the byte stream. Appendix A works through why.
 
 ## Motivation
 
 Secrets resolve from the host environment of the shuru process, which is
-frozen at exec. A VM that runs for ninety minutes against a sixty minute
-token fails with an auth error after most of the work is already done. The
-only workaround today is to split the task across VM boots using checkpoints.
+frozen at exec. A VM that runs for ninety minutes against a sixty minute token
+fails with an auth error after most of the work is already done. The only
+workaround today is to split the task across VM boots using checkpoints.
 
 The alternative users reach for otherwise is a long lived personal access
 token, which is strictly worse: broader scope, no expiry, and a much larger
@@ -29,55 +33,49 @@ blast radius if the host is compromised.
 
 Refreshing on the host side preserves the property the proxy exists to
 provide. Real credentials stay outside the VM, the guest holds a placeholder
-it cannot redeem anywhere except the bound hosts, and now the guest cannot
-retain anything useful even in the window where it holds a live session.
+it cannot redeem anywhere except the bound hosts, and the guest cannot retain
+anything useful even in the window where it holds a live session.
 
 ## Non-goals
 
 - A control socket or `shuru secret set` command. That needs a per VM control
   plane, which does not exist and should not be motivated by secrets alone.
-- File watching. Secrets at rest plus partial write races, for no benefit
-  over a command.
+- File watching. Secrets at rest plus partial write races, for no benefit over
+  a command.
 - A CLI flag for command backed secrets. The `--secret NAME=ENV@hosts` syntax
   does not extend to argv without quoting hazards. Config file only.
 - Refreshing on an upstream 401. Expiry driven refresh covers the reported
   case; reactive refresh is future work.
-- Re-resolving inside a live connection. See the granularity note below.
+- Substituting inside request bodies. See appendix A.
+- Redacting secrets out of responses. See appendix B.
 
 ## Background
 
-Secrets flow through three points today.
+Secrets flow through three points.
 
 `ProxyConfig.secrets` maps a guest visible env var name to a `SecretConfig`
 with `from` (host env var), `hosts` (domains where substitution is allowed),
-and an optional literal `value` (`crates/shuru-proxy/src/config.rs:39`).
+and an optional literal `value`.
 
-At proxy start, one random placeholder per secret is generated
-(`crates/shuru-proxy/src/lib.rs:109`) and handed to the guest as the value of
-the env var at exec time (`crates/shuru-cli/src/vm.rs:418`,
-`crates/shuru-sdk/src/lib.rs:963`).
+At proxy start, one random placeholder per secret is generated and handed to
+the guest as the value of that env var at exec time.
 
-At TLS connection setup, `secrets_for_domain` matches the SNI against the
-bound hosts and reads `std::env::var(&secret.from)` to build a list of
-placeholder to real value pairs (`crates/shuru-proxy/src/config.rs:104`).
-That list is captured once and passed into `handle_mitm`, which byte replaces
-the placeholder in every chunk flowing guest to upstream
-(`crates/shuru-proxy/src/proxy.rs:352`).
+At TLS connection setup the SNI is matched against the bound hosts, and the
+resulting placeholder to value pairs are applied to the guest to upstream
+stream.
 
-So the value is already re-read per connection rather than cached at launch.
-It simply never changes, because the process environment cannot change.
-Mutating it is not an option either: `std::env::set_var` is unsafe in a
-multithreaded process under the 2024 edition, and the proxy runs on its own
-threads.
+The value was already re-read per connection rather than cached at launch. It
+simply never changed, because the process environment cannot change. Mutating
+it is not an option either: `std::env::set_var` is unsafe in a multithreaded
+process under the 2024 edition, and the proxy runs on its own threads.
 
-Prior art converges on the same answer. The AWS `credential_process` runs a
-command that prints JSON with an `Expiration` field, and the SDK re-runs it
-when the clock passes that time. Git credential helpers added
-`password_expiry_utc` in 2.41 for exactly the GitHub App case. Docker
-credential helpers pass the target host in on stdin but have no expiry
-concept, so they pay a subprocess spawn on every operation. This design takes
-the AWS shape, since the bound hosts are already known from config and there
-is nothing to pass in.
+Prior art converges on one answer for refresh. AWS `credential_process` runs a
+command that prints JSON with an `Expiration` field and re-runs it when the
+clock passes that time. Git credential helpers added `password_expiry_utc` in
+2.41 for exactly the GitHub App case. Docker credential helpers pass the
+target host in on stdin but have no expiry concept, so they pay a subprocess
+spawn on every operation. This design takes the AWS shape, since the bound
+hosts are already known from config and there is nothing to pass in.
 
 ## Design
 
@@ -101,8 +99,8 @@ is nothing to pass in.
 }
 ```
 
-Exactly one of `from` or `command` must be set. Both set, or neither, is a
-config error reported at load time rather than at first request.
+Exactly one of `from` or `command` must be set. Both, or neither, is a config
+error reported at load time rather than at first request.
 
 `command` is an argv array, not a shell string. No shell sits between shuru
 and a credential, and there is no quoting hazard for paths with spaces.
@@ -113,9 +111,9 @@ command reports no expiry of its own.
 ### Provider contract
 
 The command runs with stdin closed, inheriting the host environment of the
-shuru process, with the working directory set to the directory containing the
-resolved config file so relative program paths and relative paths inside the
-script both behave predictably.
+shuru process, with the working directory set to the directory holding the
+resolved config file so relative paths behave the same wherever shuru is
+invoked from.
 
 On success it exits zero having written one JSON object to stdout:
 
@@ -129,24 +127,24 @@ On success it exits zero having written one JSON object to stdout:
 
 - `version` must be 1. Unknown versions are a resolve failure, which reserves
   room to change the shape later.
-- `value` is the credential, used verbatim. Trailing newline is trimmed.
-- `expires_at` is optional RFC3339. Present means refresh at that time.
-  Absent falls back to `ttl`. Absent with no `ttl` means fetch once and never
+- `value` is the credential, used verbatim. A trailing newline is trimmed.
+- `expires_at` is optional RFC3339. Present means refresh at that time. Absent
+  falls back to `ttl`. Absent with no `ttl` means fetch once and never
   refresh, matching `credential_process`.
 
-Any of a non-zero exit, unparseable stdout, an empty `value`, or a timeout is
-a resolve failure. The default timeout is 10 seconds and the process is
-killed on expiry.
+A non-zero exit, unparseable stdout, an empty `value`, or a timeout is a
+resolve failure. The timeout is 10 seconds and the process is killed on
+expiry.
 
 Stderr is captured, truncated to 4 KB, and surfaced only in the resolve
-failure message. Stdout is never logged at any level, including under
-`--verbose`, since it holds the credential.
+failure message. Stdout is never logged at any level, since it holds the
+credential, and `Minted` deliberately has no `Debug` implementation so a
+credential cannot reach a panic message.
 
 ### Resolution and caching
 
-A new `SecretResolver` in shuru-proxy owns what `ProxyConfig` cannot, since
-the engine holds the config as an immutable `Arc<ProxyConfig>`
-(`crates/shuru-proxy/src/proxy.rs:27`):
+`SecretResolver` owns what `ProxyConfig` cannot, since the engine holds the
+config as an immutable `Arc<ProxyConfig>`:
 
 ```rust
 pub struct SecretResolver {
@@ -154,144 +152,264 @@ pub struct SecretResolver {
     placeholders: HashMap<String, String>,
     cache: Mutex<HashMap<String, CacheEntry>>,
 }
-
-struct CacheEntry {
-    value: String,
-    expires_at: Option<Instant>,
-}
 ```
 
-`secrets_for_domain` becomes an async method on the resolver with the same
-return type, called from the same place at connection setup
-(`crates/shuru-proxy/src/proxy.rs:229`). `handle_mitm` keeps its existing
-`Vec<(String, String)>` parameter and needs no change.
+Env backed secrets keep reading `std::env::var` with no caching, which is free
+and preserves earlier behaviour exactly.
 
-Env backed secrets keep reading `std::env::var` with no caching, which is
-free and preserves current behavior exactly.
+Command backed secrets resolve against the cache. A cached entry with no
+expiry, or an expiry more than the refresh window away, is returned as is;
+otherwise the command runs and the result is stored. The refresh window is 60
+seconds, so a value is re-minted shortly before it dies rather than at the
+first request that fails.
 
-Command backed secrets resolve against the cache:
+Concurrent connections must not each spawn a process. The cache mutex is held
+across the fetch, so the first caller runs the command and the rest wait and
+observe the fresh entry. The mutex is per resolver rather than per secret,
+which serialises two different secrets in the rare case they lapse together.
+That is acceptable against a 10 second worst case and avoids a map of
+in-flight futures.
 
-1. A cached entry with no expiry, or an expiry more than the refresh window
-   away, is returned as is.
-2. Otherwise run the command, store the result, return it.
+### Where substitution applies
 
-The refresh window is 60 seconds, so a value is re-minted shortly before it
-dies rather than at the first request that fails.
+Substitution is scoped to the request head: the request line and every header
+value. It is scoped by position, not by header name, so any header carries a
+secret, including one this project has never heard of. A user writing
+`X-My-Vendor-Token: $API_KEY` needs no configuration and there is no provider
+table to maintain. The request line covers credentials passed as query
+parameters, such as the Google `?key=` form.
 
-Concurrent connections to the same host must not each spawn a process. The
-cache mutex is held across the fetch for that secret, so the first caller
-runs the command and the rest wait and observe the fresh entry. The mutex is
-per resolver rather than per secret, which serializes two different expiring
-secrets in the rare case they lapse together. That is acceptable against a 10
-second worst case and avoids a map of in-flight futures.
+Bodies stream through untouched.
+
+This is what makes the relay deterministic. At an arbitrary byte offset, "no
+more bytes yet" and "the request ended" are indistinguishable without a clock.
+A head that has not reached its terminating CRLF CRLF is unambiguously an
+unfinished request, so holding it is correct rather than a guess, and the
+upstream is waiting on those bytes regardless.
+
+Framing is read, never rewritten, and only to find where a body ends and the
+next head begins on a reused connection. Bodies are never modified, so no
+declared length is ever invalidated and nothing has to be recomputed. Framing
+follows the RFC 9112 section 6.3 algorithm, and anything that section calls
+out as a possible smuggling attempt is treated as ambiguous rather than
+resolved: both `Content-Length` and `Transfer-Encoding` present, conflicting
+`Content-Length` values, an unparseable head, `CONNECT`, or an `Upgrade`.
+Ambiguity stops substitution for the rest of the connection and degrades to a
+plain byte tunnel, which is the pre-existing behaviour rather than a guessed
+boundary. An intermediary that never re-frames cannot desynchronise its
+upstream by re-framing wrongly, so the smuggling exposure of a rewriting proxy
+does not arise.
+
+A head is bounded at 64 KiB. A larger one is released and the connection
+tunnelled, so nothing buffers without bound.
+
+This is also less work per byte than replacing over the whole stream, which
+scanned every byte of every body once per secret. Only heads are scanned now:
+roughly 200x less on an 80 KB upload, 2500x less on 1 MB.
 
 ### Refresh granularity
 
-Substitution values are captured once per TLS connection. A connection held
-open across an expiry boundary keeps using the value it started with.
+Values resolve at TLS connection setup, and a live relay re-resolves every 5
+seconds as it forwards, so a rotation reaches a connection that is already
+open rather than waiting for it to reconnect. Fresh values apply from the next
+request head.
 
-This is sufficient for the motivating case. An agent doing `git push` or an
-API call ninety minutes in opens a new connection, which resolves fresh. The
-gap is a single long lived keep-alive or HTTP/2 connection that spans the
-rotation, where the guest sees one auth failure and gets a working value on
-reconnect.
+The relay can simply await the resolver, because it is already an async loop.
+An earlier draft assumed this needed a lock free read plus a background
+refresh task; it does not. While the cached value is live the re-resolve is a
+mutex and a map lookup, and a re-mint costs that connection what it would have
+cost at setup, bounded by the same provider timeout.
 
-Closing that gap means re-reading the cache inside the relay loop, which
-needs a lock free read on the hot path (an `ArcSwap` load per chunk) plus a
-background refresh task, since the loop cannot await a subprocess. Deferred
-until something demonstrates it matters.
+## Failure handling
 
-### Failure handling
-
-| Condition | Behavior |
+| Condition | Behaviour |
 | --- | --- |
-| Both or neither of `from` and `command` set | Config error at load |
+| Both or neither of `from` and `command` set | Config error at load, names the secret |
 | Command fails, no cached value | Fail the connection with a clear error |
-| Command fails, unexpired value cached | Serve the cached value, log under verbose |
+| Command fails, unexpired value cached | Serve the cached value, log under warn |
 | Command fails, cached value already expired | Fail the connection |
-| Env var missing (`from` secrets) | Skip substitution, unchanged behavior |
+| Env var missing (`from` secrets) | Skip substitution, unchanged behaviour |
+| Ambiguous or unparseable HTTP framing | Stop substituting, tunnel the connection |
 
-Command backed secrets fail closed. Forwarding a placeholder to GitHub
-produces a confusing 401 that reads like a scope problem, and there is no
-reason to spend an upstream request on a value known to be wrong.
+Command backed secrets fail closed. Forwarding a placeholder to an upstream
+produces a 401 that reads like a scope problem, and there is no reason to
+spend a request on a value known to be wrong. The failure is logged at warn
+with the provider stderr, since the guest only sees a dropped TLS connection.
 
-Env backed secrets keep the existing skip behavior so nothing that works
-today starts failing. The inconsistency is deliberate and noted below.
+Env backed secrets keep the existing skip behaviour so nothing that works
+today starts failing.
 
 ## Security
 
-The credential still never enters the VM. The placeholder is generated once
-per proxy and injected at exec, so a refresh changes only the host side
-substitution table and the guest observes nothing.
+The credential still never enters the VM by way of the proxy. The placeholder
+is generated once per proxy and injected at exec, so a refresh changes only
+the host side substitution table and the guest observes nothing.
 
 Refreshing narrows the window. A guest that exfiltrates a live session gains
 nothing durable, because the value it was transiting expires on schedule and
-the replacement is minted outside the VM. Compared against the long lived PAT
-this replaces, that is a clear improvement.
+the replacement is minted outside the VM.
+
+Narrowing substitution to the head also removes a way for a guest to have the
+proxy write a credential into arbitrary data it controls: a placeholder
+appearing in a body is now left alone.
 
 New surface is one subprocess spawned by the host, from an argv array in a
 config file the user controls, with no guest input reaching it. A hostile
-`shuru.json` can already set `command` in the top level config and run
-arbitrary code on `shuru run`, so this adds no capability that did not exist.
+`shuru.json` can already run arbitrary code on `shuru run`, so this adds no
+capability that did not exist.
 
-Handling rules: the value never appears in logs, in error messages, or in
-`ps` output, and the cache is memory only with nothing written to disk.
+Substitution is best effort against a cooperative guest and is not a
+containment boundary. A guest that base64s the placeholder, splits it across
+fields, or gzips the body defeats literal matching by construction. The host
+allowlist is what actually contains the credential. Appendix B records a
+related defect that is not addressed here.
 
 ## Testing
 
-Unit:
+Unit, in `secrets.rs`: expiry math and the refresh window, the
+`expires_at` over `ttl` over never precedence, provider output parsing
+including version mismatch and garbage stdout, single flight, fail closed and
+fallback to a live cached value, and that a parse error never quotes stdout.
 
-- Expiry math, including the refresh window and the `expires_at` over `ttl`
-  over never precedence
-- Provider output parsing: version mismatch, missing `value`, trailing
-  newline, garbage stdout
-- Config validation for both and neither of `from` and `command`
-- Cached value served without re-running the command
+Unit, in `substitute.rs`: substitution in arbitrary header names and in the
+request line, at every chunk split point, bodies forwarded byte for byte,
+a second and third request on a reused connection, chunked bodies with
+extensions and trailers, and that each ambiguous framing case degrades to a
+tunnel with bytes released intact.
 
-Integration, with a script that writes a different value on each call:
+Verified end to end against a live endpoint that echoes the request:
 
-- Two connections separated by an expiry get different upstream values
-- Concurrent connections to one expired secret spawn the command once
-- A failing command fails the connection rather than forwarding a placeholder
-- A failing command with an unexpired cached value keeps serving it
-- The guest env placeholder is byte identical before and after a refresh
+- A length-changing secret substituted into a header, which previously hung
+  when the same value sat in a body.
+- A 40 KB POST body forwarded untouched with the header substituted.
+- A placeholder in a body carried through verbatim, returning 200 rather than
+  hanging.
+- Five requests on one connection, five substitutions, no placeholder leaked.
+- A rotation picked up mid-connection: 614 tokens took the first minted value
+  and 386 the second, on one connection.
 
 ## Rollout
 
-Additive. Existing configs use `from` and behave exactly as they do today.
+Additive for configuration. Existing configs using `from` behave as before.
 
-`SecretConfig` is re-exported from shuru-sdk
-(`crates/shuru-sdk/src/lib.rs:12`), so the field changes are a breaking change
-for SDK consumers building it as a struct literal. It gains `Default`, the
-two literals in shuru-cli move to struct update syntax
-(`crates/shuru-cli/src/vm.rs:100`, `crates/shuru-cli/src/config.rs:46`), and
-shuru-proxy plus shuru-sdk take a minor bump.
+`SecretConfig` is re-exported from shuru-sdk, so the field changes are
+breaking for SDK consumers building it as a struct literal. It gains
+`Default`, with `SecretConfig::from_env` and `SecretConfig::from_command` as
+the constructors. shuru-proxy goes to 0.3.0 and shuru-sdk to 0.4.0.
 
-Documentation lands in `skills/shuru/references/config.md` alongside the
-existing secrets section, with the GitHub App token as the worked example.
+Behaviour change: a secret placed in a request body is no longer substituted.
+Appendix A shows this never worked for any real credential length, so no
+working configuration changes, but the failure mode moves from a hung request
+to a clean 401.
 
-## Open questions
+## Appendix A: why substitution is head scoped
 
-- Whether env backed secrets should also fail closed on a missing value. It
-  is the more defensible behavior and the current skip is closer to an
-  oversight than a decision, but changing it breaks configs that tolerate an
-  unset variable today.
-- Whether `ttl` earns its place given that any provider worth writing can
-  report `expires_at`. It exists for wrapping a command that cannot, such as
-  a bare `gh auth token`.
+### Body substitution never worked
+
+Byte substitution arrived with proxy based networking in c2b046f (v0.3.0,
+2026-03-10) as a blind replace over the guest to upstream stream, commented
+only "Replace placeholder tokens with real values". No design named bodies as
+a target, and no documentation ever mentioned them.
+
+It is therefore a side effect rather than a feature, and it never functioned,
+because placeholders are a fixed 30 bytes and framing breaks the moment the
+replacement is any other length. Nothing real is 30 bytes: a GitHub token is
+40, a legacy OpenAI key 51, an Anthropic key about 108, an AWS access key id
+20 and its secret 40, a Stripe key about 107.
+
+Measured through a real VM, holding everything constant except the length of
+the minted value:
+
+| Request shape | Length equals placeholder | Length differs |
+| --- | --- | --- |
+| Secret in a header | 200 | 200 |
+| Body with `Content-Length` | 200 | fails |
+| Body with `Transfer-Encoding: chunked` | 200 | fails |
+| Body over 1 KB, so `Expect: 100-continue` | 200 | fails |
+
+Headers are immune because framing describes the body, not the head. Every
+body framing fails once a rewrite changes the byte count: with
+`Content-Length` the upstream waits for bytes that never arrive, and with
+chunked the emitted chunk size no longer matches its data.
+
+### No comparable proxy offers it
+
+- Modal, in its credential-injection recipe, does not substitute at all. The
+  proxy composes the header itself, via a Caddy
+  `header_up x-api-key {env.ANTHROPIC_API_KEY}`.
+- Hermes iron-proxy substitutes "the proxy token wherever it appears in a
+  matched location", and enumerates them: `Authorization`, `x-api-key`,
+  `api-key`, `x-goog-api-key`, and the Google `?key=` form. Headers and query
+  parameters, never bodies.
+
+The tools that do rewrite bodies are tokenization vaults such as VGS, where
+that is the entire product and it is done with structured payload operations
+over a fully parsed message.
+
+mitmproxy documents the underlying constraint plainly: with streaming enabled
+"the response body cannot be modified by the usual means", because "if the
+transfer encoding is not chunked, you cannot simply change the content
+length", and "it is recommended not to stream messages you need to modify".
+
+### Options rejected
+
+- **A timeout on held-back fragments.** Shipped briefly. Any timer can be
+  beaten by a slow enough stream, since "no bytes for N seconds" is not the
+  same fact as "the request ended". Measured: at 50ms a 4 KB/s throttled
+  upload released 6 of 1000 placeholders early; at 2s, none. Tuned to observed
+  throughput rather than derived, and it does nothing for framing.
+- **Scaling that wait to fragment length.** Narrows both failure modes and is
+  still guessing at the same missing fact.
+- **Re-framing everything to chunked.** Legal per RFC 9112 section 7.1.4, and
+  it makes length changes free, but it rewrites requests that did not ask for
+  it and breaks any upstream requiring an exact `Content-Length`, notably S3
+  style signed uploads.
+- **A buffering relay that rewrites `Content-Length`.** Rejected on cost. It
+  introduces request smuggling exposure, which RFC 9112 section 11.2
+  describes as exploiting "differences in protocol parsing among various
+  recipients"; it gives an untrusted guest a memory lever; it turns uploads
+  into store and forward; and its over-cap path is incoherent, since a
+  placeholder detected after earlier bytes are already upstream leaves a
+  truncated request sent, which for a non-idempotent POST may have committed
+  a side effect. Even done perfectly it still fails for signed and compressed
+  bodies. All of that to preserve something that never worked.
+- **Length-matched placeholders**, generated to be exactly as long as the
+  secret so substitution preserves framing by construction. Cheap and
+  tempting, but entropy falls with the secret: 80 bits today, 40 against a 20
+  byte AWS key id, and under 10 bytes there is no room for the `shuru_tok_`
+  marker at all. A short placeholder starts colliding with ordinary request
+  text, and a collision writes a real credential into unrelated data, which is
+  worse than not substituting. Viable only with a length floor.
+
+## Appendix B: a separate defect, not fixed here
+
+Substitution is one directional. The proxy replaces the placeholder with the
+real value on the way out and does nothing on the way back, so an upstream
+that reflects the request hands the credential to the guest:
+
+```
+guest env holds: shuru_tok_18c8ae1dd13ae8680000
+"authorization":"Bearer sk-live-REAL-CREDENTIAL-DO-NOT-LEAK"
+```
+
+The guest printed the real value. This weakens the claim that the real secret
+never enters the VM, with the precondition that a host the secret is bound to
+must reflect it, which a debug endpoint or a verbose error response can do.
+Scoping substitution to the head does not address it, since a reflected header
+carries the value just the same.
+
+The fix is response side redaction, replacing the real value with the
+placeholder on the way back, and it inherits the framing problem in the
+response direction. This wants its own issue and its own design.
 
 ## Future work
 
-- Reactive refresh on an upstream 401, which covers providers that revoke
-  early and removes the dependence on accurate expiry reporting.
-- Mid-connection refresh via `ArcSwap` plus a background refresh task.
+- Reactive refresh on an upstream 401, covering providers that revoke early.
+- Policy driven header injection, where the config states that a host gets
+  `Authorization: Bearer <secret>` and the guest never holds a placeholder at
+  all. It has none of the framing risk and none of the transformation limits,
+  because the proxy composes the header rather than finding and rewriting
+  something the guest wrote. Complementary to substitution rather than a
+  replacement, since it does not cover query parameters or bodies.
 - A `shuru secret set` control command, once a general per VM control plane
   exists for port exposure and network policy changes.
-
-## Note on an unrelated defect
-
-`replace_bytes` runs per read chunk (`crates/shuru-proxy/src/proxy.rs:352`),
-so a placeholder split across two TCP segments is forwarded unsubstituted.
-This predates this RFC and is not made worse by it, but it lives in the code
-this change touches and deserves its own fix: carry a tail buffer of
-placeholder length minus one byte across chunk boundaries.

--- a/docs/rfcs/0002-refreshable-secrets.md
+++ b/docs/rfcs/0002-refreshable-secrets.md
@@ -1,0 +1,297 @@
+# RFC 0002: Refreshable secrets
+
+- Status: Draft
+- Date: 2026-08-04
+- Scope: shuru-proxy, shuru-cli config, shuru-sdk public types
+- Issue: superhq-ai/shuru#40
+
+## Summary
+
+Let a secret be backed by a command instead of a host environment variable.
+The proxy runs that command to mint the real value, caches it in memory, and
+re-runs it when the value expires. The placeholder in the guest never changes,
+so a rotation is invisible inside the VM.
+
+This makes short lived credentials usable for long running sandbox work.
+The motivating case is a GitHub App installation token, which dies after one
+hour and currently strands any agent task that outlives it.
+
+## Motivation
+
+Secrets resolve from the host environment of the shuru process, which is
+frozen at exec. A VM that runs for ninety minutes against a sixty minute
+token fails with an auth error after most of the work is already done. The
+only workaround today is to split the task across VM boots using checkpoints.
+
+The alternative users reach for otherwise is a long lived personal access
+token, which is strictly worse: broader scope, no expiry, and a much larger
+blast radius if the host is compromised.
+
+Refreshing on the host side preserves the property the proxy exists to
+provide. Real credentials stay outside the VM, the guest holds a placeholder
+it cannot redeem anywhere except the bound hosts, and now the guest cannot
+retain anything useful even in the window where it holds a live session.
+
+## Non-goals
+
+- A control socket or `shuru secret set` command. That needs a per VM control
+  plane, which does not exist and should not be motivated by secrets alone.
+- File watching. Secrets at rest plus partial write races, for no benefit
+  over a command.
+- A CLI flag for command backed secrets. The `--secret NAME=ENV@hosts` syntax
+  does not extend to argv without quoting hazards. Config file only.
+- Refreshing on an upstream 401. Expiry driven refresh covers the reported
+  case; reactive refresh is future work.
+- Re-resolving inside a live connection. See the granularity note below.
+
+## Background
+
+Secrets flow through three points today.
+
+`ProxyConfig.secrets` maps a guest visible env var name to a `SecretConfig`
+with `from` (host env var), `hosts` (domains where substitution is allowed),
+and an optional literal `value` (`crates/shuru-proxy/src/config.rs:39`).
+
+At proxy start, one random placeholder per secret is generated
+(`crates/shuru-proxy/src/lib.rs:109`) and handed to the guest as the value of
+the env var at exec time (`crates/shuru-cli/src/vm.rs:418`,
+`crates/shuru-sdk/src/lib.rs:963`).
+
+At TLS connection setup, `secrets_for_domain` matches the SNI against the
+bound hosts and reads `std::env::var(&secret.from)` to build a list of
+placeholder to real value pairs (`crates/shuru-proxy/src/config.rs:104`).
+That list is captured once and passed into `handle_mitm`, which byte replaces
+the placeholder in every chunk flowing guest to upstream
+(`crates/shuru-proxy/src/proxy.rs:352`).
+
+So the value is already re-read per connection rather than cached at launch.
+It simply never changes, because the process environment cannot change.
+Mutating it is not an option either: `std::env::set_var` is unsafe in a
+multithreaded process under the 2024 edition, and the proxy runs on its own
+threads.
+
+Prior art converges on the same answer. The AWS `credential_process` runs a
+command that prints JSON with an `Expiration` field, and the SDK re-runs it
+when the clock passes that time. Git credential helpers added
+`password_expiry_utc` in 2.41 for exactly the GitHub App case. Docker
+credential helpers pass the target host in on stdin but have no expiry
+concept, so they pay a subprocess spawn on every operation. This design takes
+the AWS shape, since the bound hosts are already known from config and there
+is nothing to pass in.
+
+## Design
+
+### Config surface
+
+`SecretEntry` gains `command` and `ttl`, and `from` becomes optional:
+
+```json
+{
+  "allow_net": true,
+  "secrets": {
+    "GITHUB_TOKEN": {
+      "command": ["./scripts/mint-installation-token.sh"],
+      "hosts": ["api.github.com", "github.com"]
+    },
+    "API_KEY": {
+      "from": "OPENAI_API_KEY",
+      "hosts": ["api.openai.com"]
+    }
+  }
+}
+```
+
+Exactly one of `from` or `command` must be set. Both set, or neither, is a
+config error reported at load time rather than at first request.
+
+`command` is an argv array, not a shell string. No shell sits between shuru
+and a credential, and there is no quoting hazard for paths with spaces.
+
+`ttl` is an optional duration string (`"45m"`, `"3600s"`) used only when the
+command reports no expiry of its own.
+
+### Provider contract
+
+The command runs with stdin closed, inheriting the host environment of the
+shuru process, with the working directory set to the directory containing the
+resolved config file so relative program paths and relative paths inside the
+script both behave predictably.
+
+On success it exits zero having written one JSON object to stdout:
+
+```json
+{
+  "version": 1,
+  "value": "ghs_...",
+  "expires_at": "2026-08-04T18:36:00Z"
+}
+```
+
+- `version` must be 1. Unknown versions are a resolve failure, which reserves
+  room to change the shape later.
+- `value` is the credential, used verbatim. Trailing newline is trimmed.
+- `expires_at` is optional RFC3339. Present means refresh at that time.
+  Absent falls back to `ttl`. Absent with no `ttl` means fetch once and never
+  refresh, matching `credential_process`.
+
+Any of a non-zero exit, unparseable stdout, an empty `value`, or a timeout is
+a resolve failure. The default timeout is 10 seconds and the process is
+killed on expiry.
+
+Stderr is captured, truncated to 4 KB, and surfaced only in the resolve
+failure message. Stdout is never logged at any level, including under
+`--verbose`, since it holds the credential.
+
+### Resolution and caching
+
+A new `SecretResolver` in shuru-proxy owns what `ProxyConfig` cannot, since
+the engine holds the config as an immutable `Arc<ProxyConfig>`
+(`crates/shuru-proxy/src/proxy.rs:27`):
+
+```rust
+pub struct SecretResolver {
+    config: Arc<ProxyConfig>,
+    placeholders: HashMap<String, String>,
+    cache: Mutex<HashMap<String, CacheEntry>>,
+}
+
+struct CacheEntry {
+    value: String,
+    expires_at: Option<Instant>,
+}
+```
+
+`secrets_for_domain` becomes an async method on the resolver with the same
+return type, called from the same place at connection setup
+(`crates/shuru-proxy/src/proxy.rs:229`). `handle_mitm` keeps its existing
+`Vec<(String, String)>` parameter and needs no change.
+
+Env backed secrets keep reading `std::env::var` with no caching, which is
+free and preserves current behavior exactly.
+
+Command backed secrets resolve against the cache:
+
+1. A cached entry with no expiry, or an expiry more than the refresh window
+   away, is returned as is.
+2. Otherwise run the command, store the result, return it.
+
+The refresh window is 60 seconds, so a value is re-minted shortly before it
+dies rather than at the first request that fails.
+
+Concurrent connections to the same host must not each spawn a process. The
+cache mutex is held across the fetch for that secret, so the first caller
+runs the command and the rest wait and observe the fresh entry. The mutex is
+per resolver rather than per secret, which serializes two different expiring
+secrets in the rare case they lapse together. That is acceptable against a 10
+second worst case and avoids a map of in-flight futures.
+
+### Refresh granularity
+
+Substitution values are captured once per TLS connection. A connection held
+open across an expiry boundary keeps using the value it started with.
+
+This is sufficient for the motivating case. An agent doing `git push` or an
+API call ninety minutes in opens a new connection, which resolves fresh. The
+gap is a single long lived keep-alive or HTTP/2 connection that spans the
+rotation, where the guest sees one auth failure and gets a working value on
+reconnect.
+
+Closing that gap means re-reading the cache inside the relay loop, which
+needs a lock free read on the hot path (an `ArcSwap` load per chunk) plus a
+background refresh task, since the loop cannot await a subprocess. Deferred
+until something demonstrates it matters.
+
+### Failure handling
+
+| Condition | Behavior |
+| --- | --- |
+| Both or neither of `from` and `command` set | Config error at load |
+| Command fails, no cached value | Fail the connection with a clear error |
+| Command fails, unexpired value cached | Serve the cached value, log under verbose |
+| Command fails, cached value already expired | Fail the connection |
+| Env var missing (`from` secrets) | Skip substitution, unchanged behavior |
+
+Command backed secrets fail closed. Forwarding a placeholder to GitHub
+produces a confusing 401 that reads like a scope problem, and there is no
+reason to spend an upstream request on a value known to be wrong.
+
+Env backed secrets keep the existing skip behavior so nothing that works
+today starts failing. The inconsistency is deliberate and noted below.
+
+## Security
+
+The credential still never enters the VM. The placeholder is generated once
+per proxy and injected at exec, so a refresh changes only the host side
+substitution table and the guest observes nothing.
+
+Refreshing narrows the window. A guest that exfiltrates a live session gains
+nothing durable, because the value it was transiting expires on schedule and
+the replacement is minted outside the VM. Compared against the long lived PAT
+this replaces, that is a clear improvement.
+
+New surface is one subprocess spawned by the host, from an argv array in a
+config file the user controls, with no guest input reaching it. A hostile
+`shuru.json` can already set `command` in the top level config and run
+arbitrary code on `shuru run`, so this adds no capability that did not exist.
+
+Handling rules: the value never appears in logs, in error messages, or in
+`ps` output, and the cache is memory only with nothing written to disk.
+
+## Testing
+
+Unit:
+
+- Expiry math, including the refresh window and the `expires_at` over `ttl`
+  over never precedence
+- Provider output parsing: version mismatch, missing `value`, trailing
+  newline, garbage stdout
+- Config validation for both and neither of `from` and `command`
+- Cached value served without re-running the command
+
+Integration, with a script that writes a different value on each call:
+
+- Two connections separated by an expiry get different upstream values
+- Concurrent connections to one expired secret spawn the command once
+- A failing command fails the connection rather than forwarding a placeholder
+- A failing command with an unexpired cached value keeps serving it
+- The guest env placeholder is byte identical before and after a refresh
+
+## Rollout
+
+Additive. Existing configs use `from` and behave exactly as they do today.
+
+`SecretConfig` is re-exported from shuru-sdk
+(`crates/shuru-sdk/src/lib.rs:12`), so the field changes are a breaking change
+for SDK consumers building it as a struct literal. It gains `Default`, the
+two literals in shuru-cli move to struct update syntax
+(`crates/shuru-cli/src/vm.rs:100`, `crates/shuru-cli/src/config.rs:46`), and
+shuru-proxy plus shuru-sdk take a minor bump.
+
+Documentation lands in `skills/shuru/references/config.md` alongside the
+existing secrets section, with the GitHub App token as the worked example.
+
+## Open questions
+
+- Whether env backed secrets should also fail closed on a missing value. It
+  is the more defensible behavior and the current skip is closer to an
+  oversight than a decision, but changing it breaks configs that tolerate an
+  unset variable today.
+- Whether `ttl` earns its place given that any provider worth writing can
+  report `expires_at`. It exists for wrapping a command that cannot, such as
+  a bare `gh auth token`.
+
+## Future work
+
+- Reactive refresh on an upstream 401, which covers providers that revoke
+  early and removes the dependence on accurate expiry reporting.
+- Mid-connection refresh via `ArcSwap` plus a background refresh task.
+- A `shuru secret set` control command, once a general per VM control plane
+  exists for port exposure and network policy changes.
+
+## Note on an unrelated defect
+
+`replace_bytes` runs per read chunk (`crates/shuru-proxy/src/proxy.rs:352`),
+so a placeholder split across two TCP segments is forwarded unsubstituted.
+This predates this RFC and is not made worse by it, but it lives in the code
+this change touches and deserves its own fix: carry a tail buffer of
+placeholder length minus one byte across chunk boundaries.

--- a/skills/shuru/references/config.md
+++ b/skills/shuru/references/config.md
@@ -48,6 +48,13 @@ Secrets let the guest use API keys without exposing the real values. The guest r
 
 The guest sees `$API_KEY=shuru_tok_...`. The real secret never enters the VM.
 
+Substitution applies to the request head: the request line and any header
+value, whatever the header is named. A custom `X-My-Vendor-Token` works with
+no extra configuration, and a credential passed as a query parameter is
+covered too. Request bodies are forwarded untouched, so a placeholder placed
+in a body reaches the upstream unsubstituted and the request fails to
+authenticate.
+
 ### Refreshing short lived credentials
 
 A secret can be minted by a command instead of read from the environment.

--- a/skills/shuru/references/config.md
+++ b/skills/shuru/references/config.md
@@ -52,9 +52,9 @@ The guest sees `$API_KEY=shuru_tok_...`. The real secret never enters the VM.
 
 A secret can be minted by a command instead of read from the environment.
 The proxy runs the command, caches what it returns, and runs it again as the
-value approaches expiry. Use this for credentials that outlive neither the
-sandbox nor the task, such as GitHub App installation tokens, which expire
-after an hour.
+value approaches expiry. Use this for credentials that expire sooner than
+the task takes to finish, such as GitHub App installation tokens, which last
+an hour.
 
 ```json
 {

--- a/skills/shuru/references/config.md
+++ b/skills/shuru/references/config.md
@@ -48,6 +48,55 @@ Secrets let the guest use API keys without exposing the real values. The guest r
 
 The guest sees `$API_KEY=shuru_tok_...`. The real secret never enters the VM.
 
+### Refreshing short lived credentials
+
+A secret can be minted by a command instead of read from the environment.
+The proxy runs the command, caches what it returns, and runs it again as the
+value approaches expiry. Use this for credentials that outlive neither the
+sandbox nor the task, such as GitHub App installation tokens, which expire
+after an hour.
+
+```json
+{
+  "allow_net": true,
+  "secrets": {
+    "GITHUB_TOKEN": {
+      "command": ["./scripts/mint-installation-token.sh"],
+      "hosts": ["api.github.com", "github.com"]
+    }
+  }
+}
+```
+
+- `command`: argv array, never passed to a shell. Runs with the working
+  directory set to the folder holding `shuru.json`, so relative paths work
+  wherever `shuru` is invoked from.
+- `ttl`: optional lifetime to assume when the command reports no expiry.
+  Accepts `"45m"`, `"3600s"`, `"2h"`, or a bare number of seconds.
+
+Set exactly one of `from` or `command` on a secret.
+
+The command writes one JSON object to stdout:
+
+```json
+{ "version": 1, "value": "ghs_...", "expires_at": "2026-08-04T18:36:00Z" }
+```
+
+- `version` must be `1`.
+- `value` is the credential.
+- `expires_at` is optional RFC3339. When present the proxy re-runs the
+  command about a minute before it expires. When absent, `ttl` applies. With
+  neither, the value is minted once and never refreshed.
+
+A non-zero exit, unparseable output, or a run longer than 10 seconds is a
+failure. If a previously minted value is still live the proxy keeps serving
+it and logs a warning; otherwise the connection is refused, rather than
+sending a placeholder upstream that would come back as a confusing auth
+error.
+
+The placeholder in the guest never changes when a value is refreshed, so
+rotation is invisible inside the VM. Minted values are held in memory only.
+
 ## Network Policy
 
 Restrict which domains the guest can reach:


### PR DESCRIPTION
Closes #40.

Two things, both in the proxy secret path: secrets that can be refreshed while the VM runs, and substitution scoped to the request head.

Full design, evidence and rejected options in [docs/rfcs/0002-refreshable-secrets.md](docs/rfcs/0002-refreshable-secrets.md).

## 1. Refreshable secrets

Secrets resolve from the host environment of the shuru process, which is frozen at exec, so a credential that expires mid-run strands the task. A GitHub App installation token lasts an hour, which is shorter than plenty of agent work.

A secret can now name a command that mints it:

```json
{
  "allow_net": true,
  "secrets": {
    "GITHUB_TOKEN": {
      "command": ["./scripts/mint-installation-token.sh"],
      "hosts": ["api.github.com", "github.com"]
    }
  }
}
```

The command prints `{"version":1,"value":"ghs_...","expires_at":"..."}` and the proxy re-runs it about a minute before that time. Same shape as `credential_process` in the aws cli, and git credential helpers added `password_expiry_utc` for exactly this case. `ttl` covers a provider that cannot report an expiry.

- argv array, never a shell. Working directory is the folder holding shuru.json.
- values in memory only, single flight so a burst mints once, and a command that fails while a live value is cached keeps serving it.
- fails closed, logging the provider stderr at warn, rather than sending a placeholder upstream that comes back as a confusing 401.
- the placeholder in the guest never changes, so rotation is invisible inside the VM.
- a live connection re-resolves every 5s, so a rotation reaches a connection that is already open.

## 2. Substitution is now scoped to the request head

Substitution was a blind byte replace over the whole stream. That failed two ways.

A placeholder straddling two reads went upstream unsubstituted, so the secret was never injected. Reproduced on an 80KB upload: 3 of 2000 leaked.

And substituting in a body changes its length while leaving the framing that declares it. Measured across framings, holding everything constant except the length of the minted value:

| Request shape | Secret length == placeholder | Length differs |
| --- | --- | --- |
| Secret in a header | 200 | 200 |
| Body with `Content-Length` | 200 | fails |
| Body with `Transfer-Encoding: chunked` | 200 | fails |
| Body over 1 KB (`Expect: 100-continue`) | 200 | fails |

Placeholders are a fixed 30 bytes and no real credential is 30 bytes (GitHub 40, OpenAI 51, Anthropic ~108, AWS 20/40, Stripe ~107), so body substitution has never worked for anyone since it shipped in v0.3.0. No comparable sandbox proxy offers it either: Modal composes the header itself, and Hermes iron-proxy scopes to `Authorization`, `x-api-key`, `api-key`, `x-goog-api-key` and `?key=`.

So substitution now applies to the request line and any header value. Scoped by **position, not by header name**, so an unknown vendor header works with no configuration, and a credential in a query parameter is covered. Bodies stream through untouched, so no declared length is ever invalidated.

### Deterministic, not timed

An unterminated head is unambiguously an unfinished request, where an arbitrary byte offset is not. So there is no flush heuristic and nothing to tune at any throughput.

Framing is read but never rewritten, only to find where the next head begins on a reused connection. Anything RFC 9112 6.3 flags as a possible smuggling attempt (both `Content-Length` and `Transfer-Encoding`, conflicting lengths, an unparseable head, `CONNECT`, `Upgrade`) stops substitution and degrades to a plain byte tunnel. An intermediary that never re-frames cannot desynchronise its upstream by re-framing wrongly, so this does not introduce the smuggling exposure a rewriting proxy would.

It is also cheaper than before: only heads are scanned, not every byte of every body.

## Behaviour change

A placeholder in a request body is no longer substituted. That never worked, but the failure moves from a hung request to a clean 401.

## Breaking

`SecretConfig.from` is now `Option<String>`, so this breaks direct consumers of shuru-proxy and shuru-sdk. Use `SecretConfig::from_env` or `SecretConfig::from_command`. shuru-proxy goes to 0.3.0, shuru-sdk to 0.4.0. shuru-cli is left for the usual release bump.

## Verification

65 unit tests, including substitution at every chunk split point of a request, arbitrary header names, reused connections, chunked bodies with extensions and trailers, and each ambiguous-framing case degrading to a tunnel with bytes released intact.

End to end on real VMs against an echoing endpoint:

- length-changing secret substituted into `Authorization` and into an unknown custom header
- 40KB POST body forwarded untouched with the header substituted
- five requests on one reused connection, five substitutions, zero placeholders leaked
- placeholder in a body carried through verbatim, 200 rather than a hang
- rotation picked up mid-connection: 614 tokens took the first minted value, 386 the second, on one connection

## Known, not fixed here

Substitution is one directional, so an upstream that reflects a request returns the real credential to the guest. Demonstrated in appendix B of the RFC. It needs response side redaction, which inherits the framing problem in the response direction, and wants its own issue.
